### PR TITLE
Fix Zenodo caching for GitHub workflow

### DIFF
--- a/.github/actions/r2x-check/action.yaml
+++ b/.github/actions/r2x-check/action.yaml
@@ -92,7 +92,7 @@ runs:
         PY
 
     - name: Save R2X system
-      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: r2x-${{ steps.resolve.outputs.scenario }}
         compression-level: 9

--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -178,6 +178,8 @@ jobs:
             inputs/remote/
             inputs/profiles_cf/
             inputs/profiles_demand/
+            inputs/profiles_dr/
+            inputs/profiles_temperature/
           key: zenodo-files-${{ steps.zenodo-files.outputs.files-hash }}-v1
           restore-keys: |
             zenodo-files-${{ steps.zenodo-files.outputs.files-hash }}-

--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -252,7 +252,7 @@ jobs:
         run: python -m pytest tests/test_outputs.py --casepath "$GITHUB_WORKSPACE/runs/${batch}_${SCENARIO}"
 
       - name: Save ReEDS run
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ matrix.scenario }}
           compression-level: 9


### PR DESCRIPTION
## Summary
The mismatch in folders/files was causing the Zenodo cache restore to fail. This fixes that.

## Technical details <!-- if any, otherwise delete -->

### Implementation notes <!-- if any, otherwise delete -->

### Additional changes <!-- if any, otherwise delete -->

### Switches added/removed/changed <!-- if any, otherwise delete -->

### Issues resolved <!-- if any, otherwise delete -->

### Known incompatibilities <!-- if any, otherwise delete -->

### Relevant sources or documentation <!-- if any, otherwise delete -->


## Charge code for review


## Validation, testing, and comparison report(s)

<!--
How did you verify that the changes...
- [ ] have the intended effects?
- [ ] have ONLY the intended effects?
-->

<!--
Include comparison reports (e.g., .pptx files generated by compare_cases.py) for cases commensurate with the level of code/data changes:
- No changes to model or data: Pacific test case only
- Changes to model or data: Full US reference case and full US decarb case
- Changes to model structure, spatial/temporal resolution, or other large changes: All cases in cases_test.csv
-->

<!--
Include additional illustrative plots describing input data, methods, testing, and/or key differences from the comparison report(s)
-->


## Checklist for author
<!-- Fill out before requesting review -->

### Details to double-check
<!-- Delete or ~~strikethrough~~ if not relevant for this PR -->
- [ ] Charge code provided for review
- [ ] Included comparison reports for appropriate test cases
- [ ] Documentation updated if necessary
  <!--
  - model_documentation.md: High-level description of default model behavior
  - user_guide.md: User/developer-facing description of model switches and input files
  - faq.md: Limitations, caveats, and known issues
  - postprocessing_tools.md: User/developer-facing description of scripts in postprocessing folder
  - README.md files: User/developer facing description of individual input folders
  -->
- If input data added/modified:
  - [ ] Dollar year recorded and converted to 2004$ for GAMS
  - [ ] Timeseries are in Central Time
  - [ ] Units are specified
  - [ ] Preprocessing steps have been documented and committed to [ReEDS_Input_Processing](https://github.com/ReEDS-Model/ReEDS_Input_Processing)
  - [ ] New large data files handled with .h5 instead of .csv
  - [ ] If spatially resolved inputs are modified, the following visualizations for each file are included in the PR description (time-averaged if the inputs are time-resolved):
    - [ ] Map of absolute values before
    - [ ] Map of absolute values after
    - [ ] Map of differences: (after - before) or (after / before)
  - If entries are added/removed/changed in the EIA-NEMS unit database:
    - [ ] Changes have been committed to [ReEDS_Input_Processing](https://github.com/ReEDS-Model/ReEDS_Input_Processing)
    - [ ] `hourlize/resource.py` was rerun to regenerate the existing/prescribed VRE capacity data
- [ ] Code formatting standardized <!-- Coding conventions: https://pages.github.nrel.gov/ReEDS/ReEDS-2.0/internal/developer_best_practices.html#coding-standards-and-conventions -->
- [ ] Reusable functions used where possible instead of copy/pasted code

### General information to guide review
<!-- These do not need to be checked to merge, but if unchecked, a deeper level of review may be required -->
- [ ] Zero impact on results of default case
- [ ] No large data file(s) added/modified
- [ ] No substantive impact on runtime for full-US reference case
- [ ] No substantive impact on folder size for full-US reference case
- [ ] No change to process flow (runbatch.py, d_solve_iterate.py)
- [ ] No change to code organization
- [ ] No change to package requirements (environment.yml or Project.toml)

#### Did you use LLM tools (chatbot or copilot) in the preparation of this PR? If so, describe how

### Tag points of contact here if you would like additional review of the relevant parts of the model
<!-- Model dimensions -->
<!-- - [ ] County resolution: @lserpe -->
<!-- - [ ] Demand data: @ahamilto -->
<!-- - [ ] Emissions: @apham -->
<!-- - [ ] Financial calculations: @wcole -->
<!-- - [ ] FINITO: @molmezt or @cavraam -->
<!-- - [ ] Hybrids: @aschleif -->
<!-- - [ ] Monte Carlo: @vduraes -->
<!-- - [ ] Sparse chronology or interday diurnal storage: @ychen10 -->
<!-- - [ ] State policies: @wcole or @aschleif -->
<!-- - [ ] Stress periods, resource adequacy, or ReEDS2PRAS/Julia: @pbrown -->
<!-- - [ ] Supply curves, hourlize, reeds_to_rev: @bsergi -->
<!-- - [ ] Time resolution: @pbrown -->
<!-- - [ ] Water cooling: @jcarag or @scohen -->

<!-- Pre/Postprocessing -->
<!-- - [ ] Dispatch mode (run_pcm.py): @pbrown -->
<!-- - [ ] Github actions: @kminderm -->
<!-- - [ ] Health impacts: @bsergi -->
<!-- - [ ] Input data structure and processing: @cobika -->
<!-- - [ ] Interactive plots (bokeh, vizit): @mmowers -->
<!-- - [ ] Land use: @bsergi -->
<!-- - [ ] R2X: @psanchez -->
<!-- - [ ] Retail rates: @wcole -->
<!-- - [ ] Static plots (single_case_plots.py, compare_cases.py): @pbrown -->
<!-- - [ ] Tableau: @ahamilto -->
<!-- - [ ] Technology value (reValue, valuestreams.py): @mmowers -->

<!-- Technologies -->
<!-- - [ ] Batteries: @wcole -->
<!-- - [ ] EV managed charging (EVMC): @mvanatta -->
<!-- - [ ] Fossil, CCS, or DAC: @mbrown1 -->
<!-- - [ ] Geothermal: @ssharma2 -->
<!-- - [ ] Hydropower or PSH: @scohen -->
<!-- - [ ] Hydrogen: @bsergi -->
<!-- - [ ] Nuclear: @wcole -->
<!-- - [ ] Solar: @wcole -->
<!-- - [ ] Transmission: @pbrown -->
<!-- - [ ] Wind: @mmowers -->
