### PR TITLE
Add Arco Python ReEDS framework comparison case

### DIFF
--- a/tests/framework_comparison/README.md
+++ b/tests/framework_comparison/README.md
@@ -56,6 +56,7 @@ approximately matching ReEDS's sequential-myopic solve structure.
 | `linopy` | `solve_linopy.py` | HiGHS (via linopy) |
 | `pyomo` | `solve_pyomo.py` | HiGHS (via highspy) |
 | `pyoptinterface` | `solve_pyoptinterface.py` | HiGHS (via pyoptinterface) |
+| `arco` | `solve_arco.py` | HiGHS (via Arco Python bindings) |
 | `gams_highs` | `solve_gams.py` | HiGHS (via GAMS subprocess) |
 | `gams_cplex` | `solve_gams.py` | CPLEX (via GAMS subprocess) |
 | `gamspy_highs` | `solve_gamspy.py` | HiGHS (via GAMSPy) |
@@ -84,6 +85,14 @@ python tests/framework_comparison/benchmark.py --frameworks gamspy_cplex --size 
 ```
 
 Results are printed to the terminal and saved as CSV in `results/`.
+
+### Running Arco standalone with `uv --script`
+
+`solve_arco.py` includes inline `uv` metadata and pins Arco to the current PR commit. You can compile/install the bindings directly from that source with:
+
+```bash
+uv run --script tests/framework_comparison/solve_arco.py
+```
 
 ### CLI options
 
@@ -139,6 +148,7 @@ To install the GAMSPy license:
 | `solve_linopy.py` | linopy implementation |
 | `solve_pyomo.py` | Pyomo implementation |
 | `solve_pyoptinterface.py` | pyoptinterface implementation |
+| `solve_arco.py` | Arco Python implementation (includes `uv --script` metadata) |
 | `solve_gams.py` | Writes a `.gms` file and invokes GAMS via subprocess |
 | `solve_gamspy.py` | GAMSPy implementation |
 | `verify_env.py` | Lightweight import and solve check (older, pre-ramping/storage version) |

--- a/tests/framework_comparison/benchmark.py
+++ b/tests/framework_comparison/benchmark.py
@@ -50,6 +50,7 @@ FRAMEWORK_REGISTRY: list[tuple[str, str, str | None]] = [
     ("linopy",         "solve_linopy",         "highs"),
     ("pyomo",          "solve_pyomo",          "highs"),
     ("pyoptinterface", "solve_pyoptinterface", "highs"),
+    ("arco",           "solve_arco",           "highs"),
     ("gams_highs",     "solve_gams",           "highs"),
     ("gams_cplex",     "solve_gams",           "cplex"),
     ("gamspy_highs",   "solve_gamspy",         "highs"),

--- a/tests/framework_comparison/solve_arco.py
+++ b/tests/framework_comparison/solve_arco.py
@@ -6,7 +6,7 @@
 # ]
 #
 # [tool.uv.sources]
-# arco = { git = "https://github.com/NatLabRockies/arco.git", rev = "88e1369a8857779a987d58aa88d521aee8634d79", subdirectory = "bindings/python" }
+# arco = { git = "https://github.com/NatLabRockies/arco.git", rev = "main", subdirectory = "bindings/python" }
 # ///
 
 """

--- a/tests/framework_comparison/solve_arco.py
+++ b/tests/framework_comparison/solve_arco.py
@@ -1,0 +1,234 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "arco",
+#   "numpy",
+# ]
+#
+# [tool.uv.sources]
+# arco = { git = "https://github.com/NatLabRockies/arco.git", rev = "88e1369a8857779a987d58aa88d521aee8634d79", subdirectory = "bindings/python" }
+# ///
+
+"""
+Arco-Python implementation of the ReEDS-representative LP test problem.
+
+All constraint and variable names mirror the GAMS originals in
+reeds/core/setup/c_model.gms and reeds/core/setup/d_objective.gms.
+"""
+
+from __future__ import annotations
+
+import time
+
+import arco
+import numpy as np
+
+from data_generator import ProblemData
+
+
+def solve(
+    data: ProblemData,
+    solver: str = "highs",
+    build_only: bool = False,
+) -> tuple[float, float, float]:
+    if solver != "highs":
+        raise ValueError("solve_arco only supports solver='highs'")
+
+    regions, techs, hours, years = data.regions, data.techs, data.hours, data.years
+    region_index = data.r_idx
+    total_hours_weight = float(np.sum(data.hours_weight))
+
+    route_active_matrix = np.zeros((len(regions), len(regions)), dtype=bool)
+    transcap_matrix = np.zeros((len(regions), len(regions)), dtype=float)
+    for r_from, r_to in data.routes:
+        row = region_index[r_from]
+        col = region_index[r_to]
+        route_active_matrix[row, col] = True
+        transcap_matrix[row, col] = float(data.transcap[(r_from, r_to)])
+
+    t0 = time.perf_counter()
+    model = arco.Model()
+
+    I = arco.IndexSet("i", members=techs)
+    R = arco.IndexSet("r", members=regions)
+    H = arco.IndexSet("h", members=hours)
+    T = arco.IndexSet("t", members=years)
+    H_ramp = H[:-1]
+    R_from = R.alias("from")
+    R_to = R.alias("to")
+
+    valcap = arco.param(data.valcap, I, R, T)
+    is_vre = arco.param(data.is_vre, I)
+    is_storage = arco.param(data.is_storage, I)
+    is_dispatch = ~is_vre & ~is_storage
+    storage_active = valcap & is_storage
+    dispatch_active = valcap & is_dispatch
+
+    cf = arco.param(data.cf, I, R, H)
+    cap_init = arco.param(data.cap_init, I, R)
+    load = arco.param(data.load, R, H, T)
+    peak_load = arco.param(data.load.max(axis=1), R, T)
+    minloadfrac = arco.param(data.minloadfrac, I)
+    min_cf = arco.param(data.min_cf, I)
+    emit_rate = arco.param(data.emit_rate, I)
+    emit_cap = arco.param(data.emit_cap, T)
+    hours_weight = arco.param(data.hours_weight, H)
+    pvf = arco.param(data.pvf, T)
+    cost_inv = arco.param(data.cost_inv, I)
+    cost_op = arco.param(data.cost_op, I)
+    startcost = arco.param(data.startcost, I)
+
+    route_active = arco.param(route_active_matrix, R_from, R_to)
+    transcap = arco.param(transcap_matrix, R_from, R_to)
+
+    cap = model.add_variables(
+        I,
+        R,
+        T,
+        bounds=arco.NonNegativeFloat,
+        active=valcap,
+        name="CAP",
+    )
+    inv = model.add_variables(
+        I,
+        R,
+        T,
+        bounds=arco.NonNegativeFloat,
+        active=valcap,
+        name="INV",
+    )
+    gen = model.add_variables(
+        I,
+        R,
+        H,
+        T,
+        bounds=arco.NonNegativeFloat,
+        active=valcap,
+        name="GEN",
+    )
+    flow = model.add_variables(
+        R_from,
+        R_to,
+        H,
+        T,
+        bounds=arco.Bounds(0, transcap),
+        active=route_active,
+        name="FLOW",
+    )
+    rampup = model.add_variables(
+        I,
+        R,
+        H_ramp,
+        T,
+        bounds=arco.NonNegativeFloat,
+        active=dispatch_active,
+        name="RAMPUP",
+    )
+    charge = model.add_variables(
+        I,
+        R,
+        H,
+        T,
+        bounds=arco.NonNegativeFloat,
+        active=storage_active,
+        name="CHARGE",
+    )
+    soc = model.add_variables(
+        I,
+        R,
+        H,
+        T,
+        bounds=arco.NonNegativeFloat,
+        active=storage_active,
+        name="SOC",
+    )
+
+    model.add_constraints(
+        cap == cap_init + np.cumsum(inv, axis=T),
+        name="eq_cap_accum",
+    )
+    model.add_constraints(
+        gen <= cf * cap,
+        name="eq_cap_limit",
+    )
+    model.add_constraints(
+        gen >= minloadfrac * cap,
+        active=valcap & (minloadfrac > 0) & ~is_storage,
+        name="eq_mingen",
+    )
+
+    imports = ((1.0 - float(data.tranloss)) * flow) @ R_from
+    exports = flow @ R_to
+    net_flow = imports - exports
+    model.add_constraints(
+        (gen @ I) + net_flow - (charge @ I) == load,
+        name="eq_supply_demand_balance",
+    )
+    model.add_constraints(
+        (cap @ I) >= (1.0 + float(data.prm)) * peak_load,
+        name="eq_reserve_margin",
+    )
+    model.add_constraints(
+        (emit_rate * hours_weight * gen) @ (I, R, H) <= emit_cap,
+        name="eq_emit_cap",
+    )
+    model.add_constraints(
+        rampup >= np.diff(gen, axis=H),
+        active=dispatch_active,
+        name="eq_ramping",
+    )
+    model.add_constraints(
+        (hours_weight * gen) @ H >= min_cf * total_hours_weight * cap,
+        active=valcap & (min_cf > 0),
+        name="eq_min_cf",
+    )
+    model.add_constraints(
+        soc <= float(data.duration_h) * cap,
+        active=storage_active,
+        name="eq_soc_cap",
+    )
+    model.add_constraints(
+        charge <= cap,
+        active=storage_active,
+        name="eq_charge_cap",
+    )
+    model.add_constraints(
+        np.roll(soc, -1, axis=H) == soc + float(data.charge_eff) * charge - gen,
+        active=storage_active,
+        name="eq_soc",
+    )
+
+    objective = (pvf * cost_inv * inv).sum()
+    objective += (pvf * cost_op * hours_weight * gen).sum()
+    objective += (pvf * startcost * rampup).sum()
+    model.minimize(objective)
+
+    build_s = time.perf_counter() - t0
+    if build_only:
+        return float("nan"), build_s, 0.0
+
+    t1 = time.perf_counter()
+    result = model.solve(
+        solver=arco.HiGHS(
+            log_to_console=False,
+            parameters={"solver": "ipm", "arco.fingerprint": "false"},
+        )
+    )
+    solve_s = time.perf_counter() - t1
+
+    if not result.is_optimal():
+        raise RuntimeError(f"HiGHS did not find an optimal solution: {result.status}")
+
+    return float(result.objective_value), build_s, solve_s
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.path.insert(0, __file__.rsplit("\\", 1)[0])
+    from data_generator import make_problem
+
+    for size in ("small", "medium", "large", "xlarge"):
+        data = make_problem(size)
+        obj, b, s = solve(data)
+        print(f"{size:6s}  obj={obj:>18,.0f}  build={b:.3f}s  solve={s:.3f}s")


### PR DESCRIPTION
## Summary
- add `solve_arco.py` under `tests/framework_comparison` following existing framework patterns
- add inline `uv --script` metadata so reviewers can run directly from this PR
- register `arco` in `benchmark.py` framework registry
- document `arco` and standalone `uv --script` run path in framework comparison README

## Validation
- `python3 -m py_compile tests/framework_comparison/solve_arco.py tests/framework_comparison/benchmark.py`
- benchmark runs executed for small/medium (all available frameworks in local env) and large (linopy + arco)
