### PR TITLE
Speed up `recf.py` and `hourly_repperiods.py` preprocessing

### DIFF
--- a/reeds/input_processing/hourly_plots.py
+++ b/reeds/input_processing/hourly_plots.py
@@ -274,11 +274,6 @@ def plot_maps(sw, inputs_case, reeds_path, figpath, periodtype='rep', crs='EPSG:
     ).rename(columns={'*h':'h'}).set_index('h').numhours
     dfcf = pd.read_csv(os.path.join(inputs_case, periodtype, 'cf_vre.csv')).rename(columns={'*i':'i'})
 
-    _sitemaps = {
-        False: reeds.io.get_sitemap(offshore=False),
-        True: reeds.io.get_sitemap(offshore=True),
-    }
-
     for tech in techs:
         ### Get supply curve
         dfsc = pd.read_csv(
@@ -286,7 +281,7 @@ def plot_maps(sw, inputs_case, reeds_path, figpath, periodtype='rep', crs='EPSG:
         ).rename(columns={'region':'r'})
         dfsc['i'] = tech + '_' + dfsc['class'].astype(str)
         ### Add geographic and CF information
-        sitemap = _sitemaps[tech == 'wind-ofs']
+        sitemap = reeds.io.get_sitemap(offshore=(True if tech == 'wind-ofs' else False))
 
         dfsc['latitude'] = dfsc.sc_point_gid.map(sitemap.latitude)
         dfsc['longitude'] = dfsc.sc_point_gid.map(sitemap.longitude)

--- a/reeds/input_processing/hourly_plots.py
+++ b/reeds/input_processing/hourly_plots.py
@@ -274,6 +274,11 @@ def plot_maps(sw, inputs_case, reeds_path, figpath, periodtype='rep', crs='EPSG:
     ).rename(columns={'*h':'h'}).set_index('h').numhours
     dfcf = pd.read_csv(os.path.join(inputs_case, periodtype, 'cf_vre.csv')).rename(columns={'*i':'i'})
 
+    _sitemaps = {
+        False: reeds.io.get_sitemap(offshore=False),
+        True: reeds.io.get_sitemap(offshore=True),
+    }
+
     for tech in techs:
         ### Get supply curve
         dfsc = pd.read_csv(
@@ -281,7 +286,7 @@ def plot_maps(sw, inputs_case, reeds_path, figpath, periodtype='rep', crs='EPSG:
         ).rename(columns={'region':'r'})
         dfsc['i'] = tech + '_' + dfsc['class'].astype(str)
         ### Add geographic and CF information
-        sitemap = reeds.io.get_sitemap(offshore=(True if tech == 'wind-ofs' else False))
+        sitemap = _sitemaps[tech == 'wind-ofs']
 
         dfsc['latitude'] = dfsc.sc_point_gid.map(sitemap.latitude)
         dfsc['longitude'] = dfsc.sc_point_gid.map(sitemap.longitude)

--- a/reeds/input_processing/hourly_repperiods.py
+++ b/reeds/input_processing/hourly_repperiods.py
@@ -28,7 +28,6 @@ import os
 import sys
 import datetime
 import pandas as pd
-import scipy
 import sklearn.cluster
 import sklearn.neighbors
 import traceback
@@ -108,7 +107,7 @@ def optimize_period_weights(profiles_fitperiods, numclusters=100):
 
     ### Input processing
     profiles_day = (
-        profiles_fitperiods.groupby(['property','region'], axis=1).mean())
+        profiles_fitperiods.T.groupby(level=['property','region']).mean().T)
     profiles_mean = profiles_day.mean()
     numdays = len(profiles_day)
     days = profiles_day.index.values
@@ -244,7 +243,7 @@ def identify_peak_containing_periods(df, hierarchy, level):
         rmap = hierarchy[level]
     dfmod = df.copy()
     dfmod.columns = dfmod.columns.map(lambda x: x.split('|')[-1]).map(rmap)
-    dfmod = dfmod.groupby(axis=1, level=0).sum()
+    dfmod = dfmod.T.groupby(level=0).sum().T
     ### Get the max value by (year,yperiod)
     dfmax = dfmod.groupby(['year','yperiod']).max()
     ### Get the max (year,yperiod) for each column
@@ -265,7 +264,7 @@ def identify_min_periods(df, hierarchy, level, prefix=''):
         rmap = hierarchy[level]
     dfmod = df[[c for c in df if c.startswith(prefix)]].copy()
     dfmod.columns = dfmod.columns.map(lambda x: x.split('|')[-1]).map(rmap)
-    dfmod = dfmod.groupby(axis=1, level=0).sum()
+    dfmod = dfmod.T.groupby(level=0).sum().T
     ### Get the mean value by (year,yperiod)
     dfmean = dfmod.groupby(['year','yperiod']).mean()
     ### Get the min (year,yperiod) for each column
@@ -339,14 +338,15 @@ def cluster_profiles(profiles_fitperiods, sw, forceperiods_yearperiod):
             sklearn.neighbors.NearestCentroid().fit(profiles_fitperiods, idx).centroids_,
             columns=profiles_fitperiods.columns,
         )
-        nearest_period = {
-            i:
-            profiles_fitperiods.loc[:,idx==i,:].apply(
-                lambda row: scipy.spatial.distance.euclidean(row, centroids.loc[i]),
-                axis=1
-            ).nsmallest(1).index[0]
-            for i in range(int(sw['GSw_HourlyNumClusters']))
-        }
+        nearest_period = {}
+        centroid_values = centroids.values
+        profile_values = profiles_fitperiods.values
+        for i in range(int(sw['GSw_HourlyNumClusters'])):
+            cluster_mask = idx == i
+            # Calculate distance from each point in the cluster to the centroid
+            dists = np.linalg.norm(profile_values[cluster_mask] - centroid_values[i], axis=1)
+            # Find the index of the point closest to the centroid
+            nearest_period[i] = profiles_fitperiods.index[cluster_mask][np.argmin(dists)]
 
         period_szn = pd.DataFrame({
             'period': profiles_fitperiods.index.values,
@@ -570,7 +570,7 @@ def main(
     recf_agg = recf_agg[tmp.index]
     columns['region'] = columns.region.map(rmap)
     recf_agg.columns = pd.MultiIndex.from_frame(columns[['tech','region']])
-    recf_agg = recf_agg.groupby(axis=1, level=['tech','region']).sum()
+    recf_agg = recf_agg.T.groupby(level=['tech','region']).sum().T
 
     ### Divide by aggregated capacity to get back to CF
     recf_agg /= sc.groupby(['tech','aggreg']).capacity.sum().rename_axis(['tech','region'])
@@ -599,7 +599,7 @@ def main(
     ### Aggregate to GSw_HourlyClusterRegionLevel
     load_agg = load.copy()
     load_agg.columns = load_agg.columns.map(rmap)
-    load_agg = load_agg.groupby(axis=1, level=0).sum()
+    load_agg = load_agg.T.groupby(level=0).sum().T
     match sw.GSw_HourlyClusterLoadNorm:
         case 'none':
             ## Don't normalize load
@@ -665,7 +665,7 @@ def main(
     ### Aggregate from hours to periods if necessary
     if sw.GSw_HourlyClusterTimestep in ['period','day','wek','week']:
         profiles_fitperiods = (
-            profiles_fitperiods_hourly.groupby(axis=1, level=['property','region']).mean())
+            profiles_fitperiods_hourly.T.groupby(level=['property','region']).mean().T)
     else:
         profiles_fitperiods = profiles_fitperiods_hourly.copy()
 
@@ -953,10 +953,19 @@ if __name__ == '__main__':
 
     ####################################################
     #%% Write timeseries data for representative periods
+    # Load shared hourly files once to avoid repeated reads across all writetimeseries calls
+    recf_input = reeds.io.read_file(os.path.join(inputs_case, 'recf.h5'), parse_timestamps=True)
+    cspcf_input = reeds.io.read_file(os.path.join(inputs_case, 'csp.h5'), parse_timestamps=True)
+    load_input = reeds.io.read_file(
+        os.path.join(inputs_case, 'load.h5'), parse_timestamps=True).unstack(level=0)
+    load_input.columns = load_input.columns.rename(['r', 't'])
+    load_input *= (1 - reeds.io.get_scalars(inputs_case)['distloss'])
+
     hourly_writetimeseries.main(
         sw=sw, reeds_path=reeds_path, inputs_case=inputs_case,
         periodtype='rep',
         make_plots=1,
+        recf_input=recf_input, cspcf_input=cspcf_input, load_input=load_input,
     )
 
     ############################################
@@ -969,6 +978,7 @@ if __name__ == '__main__':
             sw=sw, reeds_path=reeds_path, inputs_case=inputs_case,
             periodtype=f'stress{t}i0',
             make_plots=0,
+            recf_input=recf_input, cspcf_input=cspcf_input, load_input=load_input,
         )
 
     #%% All done

--- a/reeds/input_processing/hourly_writetimeseries.py
+++ b/reeds/input_processing/hourly_writetimeseries.py
@@ -60,11 +60,11 @@ def make_8760_map(period_szn, sw):
     hmap_allyrs['actual_period'] = (
         'y' + hmap_allyrs.year.astype(str)
         + ('w' if sw.GSw_HourlyType == 'wek' else 'd')
-        + hmap_allyrs.yearperiod.astype(str).map('{:>03}'.format)
+        + hmap_allyrs.yearperiod.astype(str).str.zfill(3)
     )
     hmap_allyrs['actual_h'] = (
         hmap_allyrs.actual_period
-        + 'h' + hmap_allyrs.periodhour.astype(str).map('{:>03}'.format)
+        + 'h' + hmap_allyrs.periodhour.astype(str).str.zfill(3)
     )
     hmap_allyrs['season'] = hmap_allyrs.actual_period.map(
         period_szn.set_index('actual_period').season)
@@ -74,15 +74,15 @@ def make_8760_map(period_szn, sw):
         ### If using a chronological year (i.e. 8760) the day index uses actual days
         hmap_allyrs['h'] = (
             'y' + hmap_allyrs.year.astype(str)
-            + 'd' + hmap_allyrs.yearperiod.astype(str).map('{:>03}'.format)
-            + 'h' + hmap_allyrs.periodhour.astype(str).map('{:>03}'.format)
+            + 'd' + hmap_allyrs.yearperiod.astype(str).str.zfill(3)
+            + 'h' + hmap_allyrs.periodhour.astype(str).str.zfill(3)
         )
     else:
         ### If using representative periods (days/weks) the period index uses
         ### representative periods, which are in the 'season' column
         hmap_allyrs['h'] = (
             hmap_allyrs.season
-            + 'h' + hmap_allyrs.periodhour.astype(str).map('{:>03}'.format)
+            + 'h' + hmap_allyrs.periodhour.astype(str).str.zfill(3)
         )
     ### hmap_myr (for "model years") only contains the actually-modeled periods
     hmap_myr = hmap_allyrs.dropna(subset=['season']).copy()
@@ -535,7 +535,11 @@ def main(sw, reeds_path, inputs_case, periodtype='rep', make_plots=1, logging=Tr
         os.path.join(inputs_case, 'ccseason_dates.csv'),
         index_col=['month','day'],
     ).squeeze(1)
-    hmap_allyrs['ccseason'] = hmap_allyrs.timestamp.map(lambda x: ccseason_dates[x.month, x.day])
+    _month = hmap_allyrs.timestamp.dt.month
+    _day = hmap_allyrs.timestamp.dt.day
+    hmap_allyrs['ccseason'] = ccseason_dates.loc[
+        pd.MultiIndex.from_arrays([_month, _day])
+    ].values
 
     #%%### Load full hourly RE CF, for downselection below
     #%% VRE
@@ -554,9 +558,7 @@ def main(sw, reeds_path, inputs_case, periodtype='rep', make_plots=1, logging=Tr
     rep_periods = sorted(period_szn.rep_period.unique())
 
     ### Broadcast CSP values for all techs
-    cf_rep = recf.loc[
-        recf.index.map(lambda x: any([x.startswith(i) for i in rep_periods]))
-    ]
+    cf_rep = recf.loc[recf.index.str.startswith(tuple(rep_periods))]
 
     if int(sw["GSw_CSP"]) != 0:
         cf_rep = append_csp_profiles(cf_rep=cf_rep, sw=sw)

--- a/reeds/input_processing/hourly_writetimeseries.py
+++ b/reeds/input_processing/hourly_writetimeseries.py
@@ -194,18 +194,22 @@ def get_minloading_windows(sw, h_szn, chunkmap):
     return hour_szn_group
 
 
-def get_yearly_demand(sw, hmap_myr, hmap_allyrs, inputs_case, periodtype='rep'):
+def get_yearly_demand(sw, hmap_myr, hmap_allyrs, inputs_case, periodtype='rep', load_input=None):
     """
     After clustering based on GSw_HourlyClusterYear and identifying the modeled days,
     reload the raw demand and extract the demand on the modeled days for each year.
     """
-    ### Get original demand data, subset to cluster year
-    load_in = reeds.io.read_file(
-        os.path.join(inputs_case,'load.h5'), parse_timestamps=True).unstack(level=0)
-    load_in.columns = load_in.columns.rename(['r','t'])
-    ### load.h5 is busbar load, but b_inputs.gms ingests end-use load, so scale down by distloss
-    scalars = reeds.io.get_scalars(inputs_case)
-    load_in *= (1 - scalars['distloss'])
+    if load_input is not None:
+        ### Use pre-loaded data (distloss already applied); copy to avoid mutating shared ref
+        load_in = load_input.copy()
+    else:
+        ### Get original demand data, subset to cluster year
+        load_in = reeds.io.read_file(
+            os.path.join(inputs_case,'load.h5'), parse_timestamps=True).unstack(level=0)
+        load_in.columns = load_in.columns.rename(['r','t'])
+        ### load.h5 is busbar load, but b_inputs.gms ingests end-use load, so scale down by distloss
+        scalars = reeds.io.get_scalars(inputs_case)
+        load_in *= (1 - scalars['distloss'])
 
     ### Add time index
     load_in.index = load_in.index.map(hmap_allyrs.set_index('timestamp')['actual_h']).rename('h')
@@ -394,7 +398,8 @@ def get_yearly_flexibility(
 # %% ===========================================================================
 ### --- MAIN FUNCTION ---
 ### ===========================================================================
-def main(sw, reeds_path, inputs_case, periodtype='rep', make_plots=1, logging=True):
+def main(sw, reeds_path, inputs_case, periodtype='rep', make_plots=1, logging=True,
+         recf_input=None, cspcf_input=None, load_input=None):
     """ """
     # #%% Settings for testing
     # reeds_path = os.path.realpath(os.path.join(os.path.dirname(__file__),'..'))
@@ -534,12 +539,14 @@ def main(sw, reeds_path, inputs_case, periodtype='rep', make_plots=1, logging=Tr
 
     #%%### Load full hourly RE CF, for downselection below
     #%% VRE
-    recf = reeds.io.read_file(os.path.join(inputs_case, 'recf.h5'), parse_timestamps=True)
+    if recf_input is None:
+        recf_input = reeds.io.read_file(os.path.join(inputs_case, 'recf.h5'), parse_timestamps=True)
+    if cspcf_input is None:
+        cspcf_input = reeds.io.read_file(os.path.join(inputs_case, 'csp.h5'), parse_timestamps=True)
     ### Overwrite CSP CF (which in recf.h5 is post-storage) with solar field CF
-    cspcf = reeds.io.read_file(os.path.join(inputs_case, 'csp.h5'), parse_timestamps=True)
     recf = (
-        recf.drop([c for c in recf if c.startswith('csp')], axis=1)
-        .merge(cspcf, left_index=True, right_index=True)
+        recf_input.drop([c for c in recf_input if c.startswith('csp')], axis=1)
+        .merge(cspcf_input, left_index=True, right_index=True)
     ).loc[hmap_allyrs.timestamp]
     recf.index = hmap_allyrs.actual_h
 
@@ -1006,7 +1013,7 @@ def main(sw, reeds_path, inputs_case, periodtype='rep', make_plots=1, logging=Tr
 
     load_in, load_h = get_yearly_demand(
         sw=sw, hmap_myr=hmap_myr, hmap_allyrs=hmap_allyrs, inputs_case=inputs_case,
-        periodtype=periodtype,
+        periodtype=periodtype, load_input=load_input,
     )
 
     ###### Get the peak demand in each (r,szn,modelyear) for GSw_HourlyWeatherYears

--- a/reeds/input_processing/recf.py
+++ b/reeds/input_processing/recf.py
@@ -172,13 +172,6 @@ def calculate_class_region_cf_hourly(
         ['capacity']
         .sum()
     )
-    # Precompute weight matrix (sites × class_regions) once outside the year loop.
-    # W[j, k] = capacity[site_j] / total_capacity[class_region_k] for sites in k, else 0.
-    normalized_caps = (df_sc['capacity'] / df_sc['class_region'].map(class_region_cap)).values
-    class_region_categorical = pd.Categorical(df_sc['class_region'])
-    class_region_list = list(class_region_categorical.categories)
-    W = np.zeros((len(df_sc), len(class_region_list)))
-    W[np.arange(len(df_sc)), class_region_categorical.codes] = normalized_caps
     # Note we calculate on a per-year basis to avoid loading
     # all of the site-level hourly data in memory at once
     df_list = []
@@ -196,13 +189,14 @@ def calculate_class_region_cf_hourly(
                 year=year,
                 case=inputs_case,
             )
-        # Reorder columns to match df_sc.index for consistent matrix multiplication
+        # Downselect to relevant sites
         weather_year_site_cf_hourly = weather_year_site_cf_hourly[df_sc.index]
-        # Capacity-weighted aggregation to class-region via matrix multiply
-        weather_year_class_region_cf_hourly = pd.DataFrame(
-            weather_year_site_cf_hourly.values @ W,
-            index=weather_year_site_cf_hourly.index,
-            columns=class_region_list,
+        # Calculate the capacity-weighted average CF for each class-region pair
+        weather_year_class_region_cf_hourly = (
+            weather_year_site_cf_hourly.mul(df_sc['capacity'])
+            .rename(columns=df_sc['class_region'])
+            .T.groupby(level=0).sum().T
+            .div(class_region_cap)
         )
         # For timezone conversion, we need a few hours of CF data for the next
         # year. If we don't have data for the next year, assume the profile

--- a/reeds/input_processing/recf.py
+++ b/reeds/input_processing/recf.py
@@ -172,6 +172,13 @@ def calculate_class_region_cf_hourly(
         ['capacity']
         .sum()
     )
+    # Precompute weight matrix (sites × class_regions) once outside the year loop.
+    # W[j, k] = capacity[site_j] / total_capacity[class_region_k] for sites in k, else 0.
+    normalized_caps = (df_sc['capacity'] / df_sc['class_region'].map(class_region_cap)).values
+    class_region_categorical = pd.Categorical(df_sc['class_region'])
+    class_region_list = list(class_region_categorical.categories)
+    W = np.zeros((len(df_sc), len(class_region_list)))
+    W[np.arange(len(df_sc)), class_region_categorical.codes] = normalized_caps
     # Note we calculate on a per-year basis to avoid loading
     # all of the site-level hourly data in memory at once
     df_list = []
@@ -188,16 +195,15 @@ def calculate_class_region_cf_hourly(
                 tech=tech,
                 year=year,
                 case=inputs_case,
+                sites=df_sc.index,
             )
-        # Downselect to relevant sites
+        # Reorder columns to match df_sc.index for consistent matrix multiplication
         weather_year_site_cf_hourly = weather_year_site_cf_hourly[df_sc.index]
-        # Calculate the capacity-weighted average CF for each class-region pair
-        weather_year_class_region_cf_hourly = (
-            weather_year_site_cf_hourly.mul(df_sc['capacity'])
-            .rename(columns=df_sc['class_region'])
-            .groupby(axis=1, level=0)
-            .sum()
-            .div(class_region_cap)
+        # Capacity-weighted aggregation to class-region via matrix multiply
+        weather_year_class_region_cf_hourly = pd.DataFrame(
+            weather_year_site_cf_hourly.values @ W,
+            index=weather_year_site_cf_hourly.index,
+            columns=class_region_list,
         )
         # For timezone conversion, we need a few hours of CF data for the next
         # year. If we don't have data for the next year, assume the profile
@@ -266,9 +272,9 @@ def calculate_regional_distpv_cf(inputs_case, cap_min=0.0001):
     # regional distpv generation and dividing by each region's distpv capacity
     regional_distpv_cf = (
         county_distpv_cf.mul(county_distpv_cap)
-        .rename(columns=county2zone)
-        .groupby(axis=1, level=0)
+        .T.groupby(county2zone)
         .sum()
+        .T
         .div(regional_distpv_cap)
     )
 

--- a/reeds/input_processing/recf.py
+++ b/reeds/input_processing/recf.py
@@ -195,7 +195,6 @@ def calculate_class_region_cf_hourly(
                 tech=tech,
                 year=year,
                 case=inputs_case,
-                sites=df_sc.index,
             )
         # Reorder columns to match df_sc.index for consistent matrix multiplication
         weather_year_site_cf_hourly = weather_year_site_cf_hourly[df_sc.index]

--- a/reeds/io.py
+++ b/reeds/io.py
@@ -1059,7 +1059,7 @@ def get_temperatures(case, tz_in='UTC', tz_out='Etc/GMT+6', subset_years=True):
     return temperatures
 
 
-def get_site_cf_hourly(tech, year, case=None, sites=None, **kwargs):
+def get_site_cf_hourly(tech, year, case=None, **kwargs):
     """
     Get hourly site-level capacity factor profiles for the given tech and year
     in UTC. Note that "distpv" is not a valid input to the "tech" parameter for
@@ -1074,11 +1074,6 @@ def get_site_cf_hourly(tech, year, case=None, sites=None, **kwargs):
     determines which CF profiles are retrieved, with the former taking
     precedence. If {case} is None and a keyword argument is not provided
     for a switch, the default switch values specified in cases.csv are used.
-
-    Args:
-        sites: optional array-like of sc_point_gids to read; if provided, only
-            those columns are loaded from the (large) national HDF5 file, which
-            can reduce I/O dramatically for regional runs.
     """
     sw = reeds.io.get_switches(case, **kwargs)
     match tech:
@@ -1110,29 +1105,13 @@ def get_site_cf_hourly(tech, year, case=None, sites=None, **kwargs):
             .str
             .decode('utf-8')
         )
-        all_columns = f['columns'][:]
-        col_indices = (
-            np.where(np.isin(all_columns, np.asarray(sites)))[0]
-            if sites is not None else None
-        )
-        if col_indices is not None and len(col_indices) < len(all_columns):
-            # Only use fancy indexing when genuinely filtering — for nearly-full
-            # selections (e.g. national runs) a full read is faster on chunked HDF5
-            cf_values = (
-                f[f'cf_profile_{year}'][:, col_indices]
-                * f[f'cf_profile_{year}'].attrs['scale']
-            )
-            columns = all_columns[col_indices]
-        else:
-            cf_values = (
+        cf_hourly = pd.DataFrame(
+            index=time_index,
+            columns=f['columns'],
+            data=(
                 f[f'cf_profile_{year}'][:]
                 * f[f'cf_profile_{year}'].attrs['scale']
             )
-            columns = all_columns
-        cf_hourly = pd.DataFrame(
-            index=time_index,
-            columns=columns,
-            data=cf_values
         )
 
     return cf_hourly

--- a/reeds/io.py
+++ b/reeds/io.py
@@ -1059,7 +1059,7 @@ def get_temperatures(case, tz_in='UTC', tz_out='Etc/GMT+6', subset_years=True):
     return temperatures
 
 
-def get_site_cf_hourly(tech, year, case=None, **kwargs):
+def get_site_cf_hourly(tech, year, case=None, sites=None, **kwargs):
     """
     Get hourly site-level capacity factor profiles for the given tech and year
     in UTC. Note that "distpv" is not a valid input to the "tech" parameter for
@@ -1074,6 +1074,11 @@ def get_site_cf_hourly(tech, year, case=None, **kwargs):
     determines which CF profiles are retrieved, with the former taking
     precedence. If {case} is None and a keyword argument is not provided
     for a switch, the default switch values specified in cases.csv are used.
+
+    Args:
+        sites: optional array-like of sc_point_gids to read; if provided, only
+            those columns are loaded from the (large) national HDF5 file, which
+            can reduce I/O dramatically for regional runs.
     """
     sw = reeds.io.get_switches(case, **kwargs)
     match tech:
@@ -1105,16 +1110,27 @@ def get_site_cf_hourly(tech, year, case=None, **kwargs):
             .str
             .decode('utf-8')
         )
-        cf_values = (
-            f[f'cf_profile_{year}'][:]
-            * f[f'cf_profile_{year}'].attrs['scale']
-        )
+        all_columns = f['columns'][:]
+        if sites is not None:
+            sites_array = np.asarray(sites)
+            col_indices = np.where(np.isin(all_columns, sites_array))[0]
+            cf_values = (
+                f[f'cf_profile_{year}'][:, col_indices]
+                * f[f'cf_profile_{year}'].attrs['scale']
+            )
+            columns = all_columns[col_indices]
+        else:
+            cf_values = (
+                f[f'cf_profile_{year}'][:]
+                * f[f'cf_profile_{year}'].attrs['scale']
+            )
+            columns = all_columns
         cf_hourly = pd.DataFrame(
             index=time_index,
-            columns=f['columns'],
+            columns=columns,
             data=cf_values
         )
-    
+
     return cf_hourly
 
 def get_outage_hourly(
@@ -1794,9 +1810,7 @@ def write_profile_to_h5(df, filename, outfolder, compression_opts=4):
                 f.create_dataset(f'index_{i}', data=indexvals, dtype='S30')
             elif indexvals.name in ['datetime', 'timestamp']:
                 # if we have a formatted datetime index that isn't bytes, save as such
-                timeindex = (
-                    indexvals.to_series().apply(datetime.datetime.isoformat).reset_index(drop=True)
-                )
+                timeindex = pd.Series(indexvals.strftime('%Y-%m-%dT%H:%M:%S%z'))
                 f.create_dataset(f'index_{i}', data=timeindex.str.encode('utf-8'), dtype='S30')
             elif indexvals.dtype == 'O':
                 f.create_dataset(f'index_{i}', data=indexvals, dtype=f'S{indexvals.map(len).max()}')

--- a/reeds/io.py
+++ b/reeds/io.py
@@ -1030,7 +1030,7 @@ def get_temperatures(case, tz_in='UTC', tz_out='Etc/GMT+6', subset_years=True):
             )
             _temperatures[year] = pd.DataFrame(
                 index=timeindex,
-                columns=pd.Series(f['columns']).map(lambda x: x.decode()),
+                columns=pd.Series(f['columns']).str.decode('utf-8'),
                 data=f[str(year)],
             )
 
@@ -1128,14 +1128,14 @@ def get_outage_hourly(
         column_levels = [x.decode() for x in list(f['column_levels'])]
         if multilevel:
             columns = {
-                c: pd.Series(f[f'columns_{c}']).map(lambda x: x.decode())
+                c: pd.Series(f[f'columns_{c}']).str.decode('utf-8')
                 for c in column_levels
             }
             columns = pd.MultiIndex.from_arrays(list(columns.values()), names=columns.keys())
         else:
-            columns = pd.Series(f['columns']).map(lambda x: x.decode())
+            columns = pd.Series(f['columns']).str.decode('utf-8')
         dfout = pd.DataFrame(
-            index=pd.to_datetime(pd.Series(f['index']).map(lambda x: x.decode())),
+            index=pd.to_datetime(pd.Series(f['index']).str.decode('utf-8')),
             columns=columns,
             data=f['data'],
         ).tz_localize('UTC').tz_convert(tz)

--- a/reeds/io.py
+++ b/reeds/io.py
@@ -1111,9 +1111,13 @@ def get_site_cf_hourly(tech, year, case=None, sites=None, **kwargs):
             .decode('utf-8')
         )
         all_columns = f['columns'][:]
-        if sites is not None:
-            sites_array = np.asarray(sites)
-            col_indices = np.where(np.isin(all_columns, sites_array))[0]
+        col_indices = (
+            np.where(np.isin(all_columns, np.asarray(sites)))[0]
+            if sites is not None else None
+        )
+        if col_indices is not None and len(col_indices) < len(all_columns):
+            # Only use fancy indexing when genuinely filtering — for nearly-full
+            # selections (e.g. national runs) a full read is faster on chunked HDF5
             cf_values = (
                 f[f'cf_profile_{year}'][:, col_indices]
                 * f[f'cf_profile_{year}'].attrs['scale']

--- a/reeds/io.py
+++ b/reeds/io.py
@@ -1105,13 +1105,14 @@ def get_site_cf_hourly(tech, year, case=None, **kwargs):
             .str
             .decode('utf-8')
         )
+        cf_values = (
+            f[f'cf_profile_{year}'][:]
+            * f[f'cf_profile_{year}'].attrs['scale']
+        )
         cf_hourly = pd.DataFrame(
             index=time_index,
             columns=f['columns'],
-            data=(
-                f[f'cf_profile_{year}'][:]
-                * f[f'cf_profile_{year}'].attrs['scale']
-            )
+            data=cf_values
         )
 
     return cf_hourly


### PR DESCRIPTION
## Summary

Performance improvements for `recf.py` and `hourly_repperiods.py`, with changes to other scripts that are called by those two input processing files. The bulk fo the changes are to `hourly_repperiods.py` and related files because `recf.py` is mostly slow because of reading the large data files. This PR does not result in model changes.

## Technical details

### Implementation notes

- **`recf.py`**: Replace deprecated `groupby(axis=1)` with transposed groupby.
- **`hourly_repperiods.py`**: Load `recf.h5`, `csp.h5`, and `load.h5` once before the loop over `ndays` values and pass them into each `hourly_writetimeseries.main` call, avoiding repeated HDF5 reads. Replace deprecated `groupby(axis=1)` with transposed groupby. Replace `scipy.spatial.distance.euclidean` with `np.linalg.norm`.
- **`hourly_writetimeseries.py`**: Vectorize ccseason lookup (replaces per-element lambda with `MultiIndex.loc`); replace `.map('{:>03}'.format)` with `.str.zfill(3)`; replace per-element `any([x.startswith(i) for i in rep_periods])` lambda with `str.startswith(tuple(rep_periods))`. Add `recf_input`/`cspcf_input`/`load_input` pass-through parameters (default `None` preserves existing call sites).
- **`hourly_plots.py`**: Cache `get_sitemap()` results outside the tech loop in `plot_maps`, saving one redundant HDF5 read + GeoDataFrame CRS projection.
- **`reeds/io.py`**: Replace `.map(lambda x: x.decode())` with `.str.decode('utf-8')` in `get_outage_hourly` and `get_temperatures`. Vectorize datetime formatting in `write_profile_to_h5` with `strftime` instead of per-element `apply`.

## Validation, testing, and comparison report(s)

The Pacific case, USA_defaults, and WECC_county cases all had no changes to inputs.gdx with the changes made here.  My USA_defaults test case showed no changes for any output except runtime: [results-Main,Speedup.pptx](https://github.com/user-attachments/files/27774676/results-Main.Speedup.pptx).

Total input processing speed went down by 18% (1.4 minutes) for Pacific, 19% (5.2 minutes) for USA_defaults, and 10% (2.3 minutes) for WECC_county.  These are more modest than I was hoping, but given that I already made them, I think it's still worth pushing into the model.  My interest in faster run time in input processing is for debugging so that I don't need to wait as long for a new run to get to the part of the model that I want to test, and this helps at least a little with that.

## Checklist for author
<!-- Fill out before requesting review -->

### Details to double-check
<!-- Delete or ~~strikethrough~~ if not relevant for this PR -->
- [x] Charge code provided to reviewers
- [x] Included comparison reports for appropriate test cases
- ~~Documentation updated if necessary~~
- ~~Dollar year recorded and converted to 2004$ for GAMS~~
- ~~Timeseries are in Central Time~~
- ~~Units are specified~~
- ~~Preprocessing steps have been documented and committed to [ReEDS_Input_Processing](https://github.com/ReEDS-Model/ReEDS_Input_Processing)~~
- ~~New large data files handled with .h5 instead of .csv~~

### General information to guide review
<!-- These do not need to be checked to merge, but if unchecked, a deeper level of review may be required -->
- [x] Zero impact on results of default case
- [x] No large data file(s) added/modified
- [x] No substantive impact on runtime for full-US reference case
- [x] No change to process flow (runreeds.py, solve.py)
- [x] No change to code organization
- [x] No change to package requirements (environment.yml or Project.toml)

#### Did you use LLM tools (chatbot or copilot) in the preparation of this PR? If so, describe how

Yes — Claude (Sonnet 4.6 via Claude Code) was used to identify hotspots via `cProfile`, implement and verify the optimizations, and confirm output equivalence.
