### PR TITLE
End ReEDS run early if no valid scenarios

### DIFF
--- a/runreeds.py
+++ b/runreeds.py
@@ -854,6 +854,7 @@ def setupEnvironment(
         single=single,
         skip_checks=skip_checks,
     )
+    all_case_names = list(df_cases.columns)
     ## Propagate debug setting
     if debug:
         df_cases.loc['debug'] = str(debug)
@@ -885,8 +886,8 @@ def setupEnvironment(
         for s in single.split(','):
             if s not in df_cases:
                 err = (
-                    f'Specified single={single} but available cases are:\n'
-                    + '\n> '.join([c for c in df_cases.columns])
+                    f'Specified single={single} but available cases are: '
+                    + ', '.join([c for c in df_cases.columns])
                 )
                 raise KeyError(err)
         df_cases = df_cases[single.split(',')].copy()
@@ -896,6 +897,9 @@ def setupEnvironment(
     outpaths = [os.path.join(reeds_path,'runs',f'{BatchName}_{case}') for case in casenames]
     existing_outpaths = [i for i in outpaths if os.path.isdir(i)]
     if len(existing_outpaths):
+        if len(existing_outpaths) == 0:
+            print('Existing output directories were not overwritten. Exiting without starting runs.')
+            quit()
         print(
             f'The following {len(existing_outpaths)} output directories already exist:\n'
             + 'vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n'
@@ -908,6 +912,9 @@ def setupEnvironment(
                 shutil.rmtree(outpath)
         else:
             keep = [i for (i,c) in enumerate(outpaths) if c not in existing_outpaths]
+            if len(keep) == 0:
+                print('All output directories already exist and were not overwritten. Exiting without starting runs.')
+                quit()
             caseList = [caseList[i] for i in keep]
             casenames = [casenames[i] for i in keep]
             caseSwitches = [caseSwitches[i] for i in keep]
@@ -920,6 +927,11 @@ def setupEnvironment(
             skip = str(input('Do you want to run them and skip the rest? [y]/n: ') or 'y')
             if skip.lower() not in ['y','yes']:
                 raise IsADirectoryError('\n'+'\n'.join(existing_outpaths))
+
+    # Exit early if no runnable cases remain after filtering
+    if len(caseList) == 0:
+        print(f"All {len(all_case_names)} scenario(s) in {cases_filename} have ignore=1. Exiting without starting runs.")
+        quit()
 
     #%% User warnings
     if (df_cases.loc['cleanup_level'].astype(int) > 0).any() and not skip_checks:
@@ -951,6 +963,9 @@ def setupEnvironment(
         WORKERS = simult_runs
     else:
         WORKERS = int(input('Number of simultaneous runs [integer]: '))
+        if WORKERS <=0:
+            print('Number of simultaneous runs must be at least 1. Exiting.')
+            quit()
 
     if 'int' in df_cases.loc['timetype'].tolist() or 'win' in df_cases.loc['timetype'].tolist():
         ccworkers = int(input('Number of simultaneous CC/Curt runs [integer]: '))

--- a/runreeds.py
+++ b/runreeds.py
@@ -959,7 +959,7 @@ def setupEnvironment(
     elif simult_runs > 0:
         WORKERS = simult_runs
     else:
-        WORKERS = int(input('Number of simultaneous runs [integer]: '))
+        WORKERS = int(input('Number of simultaneous runs [positive integer]: '))
         if WORKERS <=0:
             print('Number of simultaneous runs must be at least 1. Exiting.')
             quit()

--- a/runreeds.py
+++ b/runreeds.py
@@ -960,9 +960,8 @@ def setupEnvironment(
         WORKERS = simult_runs
     else:
         WORKERS = int(input('Number of simultaneous runs [positive integer]: '))
-        if WORKERS <=0:
-            print('Number of simultaneous runs must be at least 1. Exiting.')
-            quit()
+        if WORKERS <= 0:
+            raise ValueError(f'Provided {WORKERS} but must be a positive integer')
 
     if 'int' in df_cases.loc['timetype'].tolist() or 'win' in df_cases.loc['timetype'].tolist():
         ccworkers = int(input('Number of simultaneous CC/Curt runs [integer]: '))

--- a/runreeds.py
+++ b/runreeds.py
@@ -886,10 +886,10 @@ def setupEnvironment(
         for s in single.split(','):
             if s not in df_cases:
                 err = (
-                    f'Specified single={single} but available cases are: '
-                    + ', '.join([c for c in df_cases.columns])
+                    f'Specified single={single} but available cases are:\n'
+                    + '\n> '.join([c for c in df_cases.columns])
                 )
-                raise KeyError(err)
+                raise ValueError(err)
         df_cases = df_cases[single.split(',')].copy()
         casenames = single.split(',')
 

--- a/runreeds.py
+++ b/runreeds.py
@@ -854,7 +854,6 @@ def setupEnvironment(
         single=single,
         skip_checks=skip_checks,
     )
-    all_case_names = list(df_cases.columns)
     ## Propagate debug setting
     if debug:
         df_cases.loc['debug'] = str(debug)
@@ -926,6 +925,7 @@ def setupEnvironment(
                 raise IsADirectoryError('\n'+'\n'.join(existing_outpaths))
 
     # Exit early if no runnable cases remain after filtering
+    all_case_names = list(df_cases.columns)
     if len(caseList) == 0:
         print(f"All {len(all_case_names)} scenario(s) in {cases_filename} have ignore=1. Exiting without starting runs.")
         quit()

--- a/runreeds.py
+++ b/runreeds.py
@@ -897,9 +897,6 @@ def setupEnvironment(
     outpaths = [os.path.join(reeds_path,'runs',f'{BatchName}_{case}') for case in casenames]
     existing_outpaths = [i for i in outpaths if os.path.isdir(i)]
     if len(existing_outpaths):
-        if len(existing_outpaths) == 0:
-            print('Existing output directories were not overwritten. Exiting without starting runs.')
-            quit()
         print(
             f'The following {len(existing_outpaths)} output directories already exist:\n'
             + 'vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n'


### PR DESCRIPTION
## Summary
This PR updates `runreeds.py` to end the run in a few different places if there are no valid scenarios left.

I also did a minor update to one of the existing error messages so it was easier to read.

## Validation, testing, and comparison report(s)
I didn't do a full run since it doesn't change the model itself. I did check all combinations of getting a run started to make sure it behaved as expected.

<!--
How did you verify that the changes...
- [ ] have the intended effects?
- [ ] have ONLY the intended effects?
-->

<!--
Include comparison reports (e.g., .pptx files generated by compare_cases.py) for cases commensurate with the level of code/data changes:
- No changes to model or data: Pacific test case only
- Changes to model or data: Full US reference case and full US decarb case
- Changes to model structure, spatial/temporal resolution, or other large changes: All cases in cases_test.csv
-->

<!--
Include additional illustrative plots describing input data, methods, testing, and/or key differences from the comparison report(s)
-->


## Checklist for author
<!-- Fill out before requesting review -->

### Details to double-check
<!-- Delete or ~~strikethrough~~ if not relevant for this PR -->
- [ ] Charge code provided to reviewers
- [ ] Included comparison reports for appropriate test cases
- [ ] Documentation updated if necessary
  <!--
  - model_documentation.md: High-level description of default model behavior
  - user_guide.md: User/developer-facing description of model switches and input files
  - faq.md: Limitations, caveats, and known issues
  - postprocessing_tools.md: User/developer-facing description of scripts in postprocessing folder
  - README.md files: User/developer facing description of individual input folders
  -->
- If input data added/modified:
  - [ ] Dollar year recorded and converted to 2004$ for GAMS
  - [ ] Timeseries are in Central Time
  - [ ] Units are specified
  - [ ] Preprocessing steps have been documented and committed to [ReEDS_Input_Processing](https://github.com/ReEDS-Model/ReEDS_Input_Processing)
  - [ ] New large data files handled with .h5 instead of .csv
  - [ ] If spatially resolved inputs are modified, the following visualizations for each file are included in the PR description (time-averaged if the inputs are time-resolved):
    - [ ] Map of absolute values before
    - [ ] Map of absolute values after
    - [ ] Map of differences: (after - before) or (after / before)
  - If entries are added/removed/changed in the EIA-NEMS unit database:
    - [ ] Changes have been committed to [ReEDS_Input_Processing](https://github.com/ReEDS-Model/ReEDS_Input_Processing)
    - [ ] `hourlize/resource.py` was rerun to regenerate the existing/prescribed VRE capacity data
- [ ] Code formatting standardized <!-- Coding conventions: https://reeds-model.github.io/ReEDS/developer_best_practices.html#coding-standards-and-conventions -->
- [ ] Reusable functions used where possible instead of copy/pasted code

### General information to guide review
<!-- These do not need to be checked to merge, but if unchecked, a deeper level of review may be required -->
- [ ] Zero impact on results of default case
- [ ] No large data file(s) added/modified
- [ ] No substantive impact on runtime for full-US reference case
- [ ] No substantive impact on folder size for full-US reference case
- [ ] No change to process flow (runreeds.py, reeds/core/solve/solve.py)
- [ ] No change to code organization
- [ ] No change to package requirements (environment.yml or Project.toml)

#### Did you use LLM tools (chatbot or copilot) in the preparation of this PR? If so, describe how

### Tag points of contact here if you would like additional review of the relevant parts of the model
<!-- Model dimensions -->
<!-- - [ ] County resolution: @louisaserpe -->
<!-- - [ ] Demand data: @ahamilton5 -->
<!-- - [ ] Emissions: @atpham88 -->
<!-- - [ ] Financial calculations: @wesleyjcole -->
<!-- - [ ] FINITO: @merveturan or @cavraam -->
<!-- - [ ] Hybrids: @aschleif -->
<!-- - [ ] Monte Carlo: @bsergi -->
<!-- - [ ] Sparse chronology or interday diurnal storage: @Yunzhi-Chen -->
<!-- - [ ] State policies: @wesleyjcole or @aschleif -->
<!-- - [ ] Stress periods, resource adequacy, or ReEDS2PRAS/Julia: @patrickbrown4 -->
<!-- - [ ] Supply curves, hourlize, reeds_to_rev: @bsergi -->
<!-- - [ ] Time resolution: @patrickbrown4 -->
<!-- - [ ] Water cooling: @jcarag or @stuartcohen8 -->

<!-- Pre/Postprocessing -->
<!-- - [ ] Dispatch mode (run_pcm.py): @patrickbrown4 -->
<!-- - [ ] Github actions: @kennedy-mindermann -->
<!-- - [ ] Health impacts: @bsergi -->
<!-- - [ ] Input data structure and processing: @kodiobika -->
<!-- - [ ] Interactive plots (bokeh, vizit): @mmowers -->
<!-- - [ ] Land use: @bsergi -->
<!-- - [ ] R2X: @pesap -->
<!-- - [ ] Retail rates: @wesleyjcole -->
<!-- - [ ] Static plots (single_case_plots.py, compare_cases.py): @patrickbrown4 -->
<!-- - [ ] Tableau: @ahamilton5 -->
<!-- - [ ] Technology value (reValue, valuestreams.py): @mmowers -->

<!-- Technologies -->
<!-- - [ ] Batteries: @wesleyjcole -->
<!-- - [ ] EV managed charging (EVMC): @Max-Vanatta -->
<!-- - [ ] Fossil, CCS, or DAC: @mbrown1 -->
<!-- - [ ] Geothermal: @shashwatsharma24 -->
<!-- - [ ] Hydropower or PSH: @stuartcohen8 -->
<!-- - [ ] Hydrogen: @bsergi -->
<!-- - [ ] Nuclear: @wesleyjcole -->
<!-- - [ ] Solar: @wesleyjcole -->
<!-- - [ ] Transmission: @patrickbrown4 -->
<!-- - [ ] Wind: @mmowers -->
