### PR TITLE
Add link to Sinnott's scheduled outage description page.

### DIFF
--- a/docs/source/model_documentation.md
+++ b/docs/source/model_documentation.md
@@ -1572,7 +1572,7 @@ Note the difference in color scales.
 
 
 Scheduled (planned and maintenance) outage rates are derived from the NERC GADS database {cite}`nercGeneratingAvailabilityData2023`.
-Scheduled outage rates for combined cycle, combustion turbine, nuclear, steam (coal), and hydro technologies are measured and applied at monthly resolution using GADS data from 2013 to 2023 {cite}`murphyGridReliabilityStatistics2025`.
+Scheduled outage rates for combined cycle, combustion turbine, nuclear, steam (coal), and hydro technologies are measured and applied at monthly resolution using GADS data from 2013 to 2023 {cite}`murphyGridReliabilityStatistics2025` (see the [scheduled outages](https://github.com/NatLabRockies/grid-reliability-statistics/blob/main/notebooks/scheduled_outages.ipynb) notebook for specific details).
 Scheduled outage rates for other technologies are measured as time-independent average values using GADS data from 2014 to 2018;
 scheduled outages for these technologies are applied only during spring and fall, with the outage rates during those months scaled to reproduce the measured time-independent averages.
 {numref}`figure-outage_scheduled` shows scheduled outage rates for the technologies used by default.


### PR DESCRIPTION
## Summary
This pull request adds a link to the documentation to the page that describes how scheduled outages were created.  We have the citation to Sinnott's repository already, but when I was looking for more information on the scheduled outages in ReEDS, I wasn't able to find this information.  I'm adding the link to make it easier for others to find the details on scheduled outages.

## Validation, testing, and comparison report(s)
There are no changes to the model data or code.  I checked a markdown preview to ensure my documentation changes render correctly.

## Checklist for author
<!-- Fill out before requesting review -->

### Details to double-check
<!-- Delete or ~~strikethrough~~ if not relevant for this PR -->
- [x] Charge code provided to reviewers
- ~~[ ] Included comparison reports for appropriate test cases~~
- [x] Documentation updated if necessary

### General information to guide review
<!-- These do not need to be checked to merge, but if unchecked, a deeper level of review may be required -->
- [x] Zero impact on results of default case
- [x] No large data file(s) added/modified
- [x] No substantive impact on runtime for full-US reference case
- [x] No substantive impact on folder size for full-US reference case
- [x] No change to process flow (runreeds.py, reeds/core/solve/solve.py)
- [x] No change to code organization
- [x] No change to package requirements (environment.yml or Project.toml)

#### Did you use LLM tools (chatbot or copilot) in the preparation of this PR? If so, describe how
No.