### PR TITLE
Ignore kmeans memory leak warning on Windows

### DIFF
--- a/reeds/input_processing/WriteHintage.py
+++ b/reeds/input_processing/WriteHintage.py
@@ -55,8 +55,10 @@ import reeds
 # Time the operation of this script
 tic = datetime.datetime.now()
 
-# ignore ConvergenceWarnings that occur in this file from the kmeans function 
+# ignore ConvergenceWarnings and Windows+MKL memory leak warnings that
+# occur in this file from the kmeans function
 warnings.filterwarnings("ignore", category=ConvergenceWarning)
+warnings.filterwarnings("ignore", message="KMeans is known to have a memory leak")
 
 
 #%% ===========================================================================


### PR DESCRIPTION
## Summary
When running on Windows, `WriteHintage.py` prints the memory leak warning below 249 times in a USA_defaults case.  This pull request suppressing that warning to give a cleaner log file on Windows.  The warning says you can set `OMP_NUM_THREADS=1`, but given this is Windows only, I opted to not go that route so that we don't unintentionally impact performance on other systems, and because I've never seen any issues with a memory leak in the many years that we have been using this version of the kmeans function.

```
WriteHintage.py | 2026-05-19 17:09:44 | ERROR | C:\envs\reeds2\Lib\site-packages\sklearn\cluster\_kmeans.py:1382: UserWarning: KMeans is known to have a memory leak on Windows with MKL, when there are less chunks than available threads. You can avoid it by setting the environment variable OMP_NUM_THREADS=1.
```

## Validation, testing, and comparison report(s)
I reran `WriteHintage.py` on Windows and verified that the error/warning is no longer printed to the log file.

## Checklist for author
<!-- Fill out before requesting review -->

### Details to double-check
<!-- Delete or ~~strikethrough~~ if not relevant for this PR -->
- [x] Charge code provided to reviewers
- ~~[ ] Included comparison reports for appropriate test cases~~
- ~~[ ] Documentation updated if necessary~~
  <!--
  - model_documentation.md: High-level description of default model behavior
  - user_guide.md: User/developer-facing description of model switches and input files
  - faq.md: Limitations, caveats, and known issues
  - postprocessing_tools.md: User/developer-facing description of scripts in postprocessing folder
  - README.md files: User/developer facing description of individual input folders
  -->

### General information to guide review
<!-- These do not need to be checked to merge, but if unchecked, a deeper level of review may be required -->
- [x] Zero impact on results of default case
- [x] No large data file(s) added/modified
- [x] No substantive impact on runtime for full-US reference case
- [x] No substantive impact on folder size for full-US reference case
- [x] No change to process flow (runreeds.py, reeds/core/solve/solve.py)
- [x] No change to code organization
- [x] No change to package requirements (environment.yml or Project.toml)

#### Did you use LLM tools (chatbot or copilot) in the preparation of this PR? If so, describe how
Yes, I used an LLM to figure out how to suppress the warning message.