### PR TITLE
Docs: Change main spatial figures to 90-zone map

### DIFF
--- a/docs/source/figs/docs/local-generation-interconnection-components.png
+++ b/docs/source/figs/docs/local-generation-interconnection-components.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa4a399a49be66024f86692a7fc50821425ee259b4f9a3c285fe5c62992f0c25
-size 871554
+oid sha256:c20143195c6cc2274e0dc5b1a2ba169910f4ad7bce5b00dc9fc985f82a3c13d9
+size 832245

--- a/docs/source/figs/docs/spatial_layers_zones.png
+++ b/docs/source/figs/docs/spatial_layers_zones.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c82f7563e9bacd77c1ed7148ea9e81f74b7b1a1fa42c067952db298fde053aa7
-size 1474305
+oid sha256:91e392499f3fd5157a63d6369babbddb1d8d54026f833cd100b96d7354b0c584
+size 1526822

--- a/docs/source/figs/docs/transmission-offshore.png
+++ b/docs/source/figs/docs/transmission-offshore.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61d901d6325fd933af8d8e7fe88dabef8c2ec1b0679f349b20eeaddaf8a7ca90
-size 1586494
+oid sha256:16682a1ff6010ce6c15372908c2c7fd8fd205bffd5df1bc43f231276a3c15117
+size 1220222

--- a/docs/source/model_documentation.md
+++ b/docs/source/model_documentation.md
@@ -354,7 +354,7 @@ Methane leakage is not included in emissions estimates for transportation or res
 ### Spatial Resolution
 
 ReEDS is typically used to study the CONUS.[^ref9]
-The 132 default ReEDS model zones are shown in {numref}`figure-spatial_layers_zones`.
+The 90 default ReEDS model zones are shown in {numref}`figure-spatial_layers_zones`.
 The model zones comprise groups of counties and do not align perfectly with real balancing authority areas.
 The zones respect state boundaries, allowing the model to represent individual state regulations and incentives.
 Transmission flows across the interfaces between model zones are subject to transfer limits, as discussed in the [Transmission](#transmission) section.
@@ -365,7 +365,7 @@ Details of the implementation are not discussed here.
 ```{figure} figs/docs/spatial_layers_zones.png
 :name: figure-spatial_layers_zones
 
-Default 132 model zones and spatial layers defined by groups of zones.
+Default model zones and spatial layers defined by groups of zones.
 ```
 
 Additional spatial layers are used in different parts of the model.[^ref10]
@@ -1919,7 +1919,7 @@ in general, the ITL for power flow from Zone A to Zone B is not the same as the 
 
 As discussed in {cite}`brownGeneralMethodEstimating2023`, because of the constraints imposed by Kirchhoff's voltage law and nodal load participation factors, the ITL tends to be smaller than the sum of line ratings that cross an interface;
 that is, every transmission line between a pair of regions cannot in general be used at its rated capacity at the same time.
-{numref}`figure-transmission-itl-r` illustrates this effect for the traditional 134 ReEDS zones.
+{numref}`figure-transmission-itl-r` illustrates this effect at the level of model zones.
 The same effect is observed for larger interfaces;
 when modeled at nodal resolution,
 the maximum flow between SPP and MISO (for example) is smaller than the sum of the zonal ITLs for the zonal interfaces that span the larger SPP-MISO interface.
@@ -1940,7 +1940,7 @@ To read the ITL data for a given set of model zones, you can activate the `reeds
 import reeds
 # GSw_ZoneSet can be any of the supported values listed in the "Choices" column
 # for the `GSw_ZoneSet` switch in `cases.csv`
-GSw_ZoneSet = 'z132'
+GSw_ZoneSet = 'z90'
 reeds.inputs.get_itls(GSw_ZoneSet=GSw_ZoneSet)
 ```
 

--- a/docs/source/plotting_scripts/maps.py
+++ b/docs/source/plotting_scripts/maps.py
@@ -7,6 +7,7 @@ import shapely
 import datetime
 import numpy as np
 import pandas as pd
+from pathlib import Path
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib import patheffects as pe
@@ -328,21 +329,30 @@ offshore = offshore_zones.index.values
 dfzones = pd.concat([dfmap['r'], offshore_zones])
 
 ### Get transmission links
+case = Path(reeds.io.reeds_path,'runs','v20260713_ilM0_USA_defaults')
 trans_files = {
-    'init_ac': 'transmission_capacity_init_AC_ba_NARIS2024.csv',
-    'init_nonac': 'transmission_capacity_init_nonAC_ba.csv',
-    'fut': 'transmission_capacity_future_ba_baseline.csv',
+    'init': Path(case, 'inputs_case', 'trancap_init_energy.csv'),
+    'fut': Path(case, 'inputs_case', 'trancap_fut.csv'),
 }
-trans_links = {
-    key:
-    pd.read_csv(
-        os.path.join(
-            reeds.io.reeds_path, 'inputs', 'transmission', trans_files[key],
-        ),
+trans_links = pd.concat({
+    key: pd.read_csv(
+        Path(reeds.io.reeds_path, 'inputs', 'transmission', trans_files[key]),
         comment='#',
-    )
+    ).rename(columns={'*r':'r'})
     for key in trans_files
-}
+}, axis=0)
+## Avoid overlaps
+ls = {('AZ_S','NM_W','VSC'): '--'}
+
+sw = reeds.io.get_switches()
+newlinks_offshore = pd.concat([
+    pd.read_csv(
+        Path(reeds.io.reeds_path, 'inputs', 'zones', sw.GSw_ZoneSet, 'newlinks_offshore_radial.csv')
+    ),
+    pd.read_csv(
+        Path(reeds.io.reeds_path, 'inputs', 'transmission', 'newlinks_offshore_backbone.csv')
+    ),
+])
 
 ### Get interconnection seams
 seam_buffer = 5000
@@ -356,7 +366,7 @@ seams = gpd.GeoSeries([
 onshore_colors = mapclassify.greedy(dfmap['r'], strategy='smallest_last')
 offshore_colors = mapclassify.greedy(offshore_zones, strategy='smallest_last')
 
-### Set up the plot
+#%% Set up the plot
 alpha_zones_min = 0.15
 alpha_zones_mult = 0.05
 lw_zones = 0.3
@@ -374,6 +384,7 @@ prefix = 'centroid_'
 prefix = ''
 fontsize = 0
 fontsize = 7
+label_land = False
 
 ### Plot it
 plt.close()
@@ -395,9 +406,13 @@ for r, row in dfmap['r'].iterrows():
         ax=ax, facecolor=colors['land'], lw=0,
         alpha=alpha_zones_min+alpha_zones_mult*onshore_colors[r],
     )
-    if fontsize:
+    if label_land:
+        x, y = (
+            np.array([row.geometry.centroid.x, row.geometry.centroid.y])
+            + np.array(offset.get('r', {}).get(r, (0,0)))
+        )
         ax.annotate(
-            r, (row['centroid_x'], row['centroid_y']), ha='center', va='center',
+            r, (x, y), ha='center', va='center',
             color='k', fontsize=fontsize, zorder=1e10,
             path_effects=[pe.withStroke(linewidth=1.5, foreground='w', alpha=0.75)],
         )
@@ -405,23 +420,18 @@ offshore_zones.plot(ax=ax, facecolor='none', edgecolor=colors['offshore'], lw=lw
 dfmap['r'].plot(ax=ax, facecolor='none', edgecolor=colors['land'], lw=lw_zones, zorder=1e6)
 seams.plot(ax=ax, facecolor='k', edgecolor='w', lw=0.6, zorder=1.1e6)
 ## Links
-for i, row in trans_links['init_ac'].iterrows():
+for i, row in trans_links.iterrows():
     ax.plot(
         [dfmap['r'].loc[row.r, f'{prefix}x'], dfmap['r'].loc[row.rr, f'{prefix}x']],
         [dfmap['r'].loc[row.r, f'{prefix}y'], dfmap['r'].loc[row.rr, f'{prefix}y']],
-        color=colors['AC'], lw=lw_lines, zorder=1e7,
+        color=colors[row['trtype']], lw=lw_lines, zorder=1e7,
+        ls=ls.get((row.r,row.rr,row.trtype), ls.get((row.rr,row.r,row.trtype), '-')),
     )
-for i, row in trans_links['init_nonac'].iterrows():
-    ax.plot(
-        [dfmap['r'].loc[row.r, f'{prefix}x'], dfmap['r'].loc[row.rr, f'{prefix}x']],
-        [dfmap['r'].loc[row.r, f'{prefix}y'], dfmap['r'].loc[row.rr, f'{prefix}y']],
-        color=colors[row['trtype']], lw=lw_lines, zorder=1e8,
-    )
-for i, row in trans_links['fut'].iterrows():
+for i, row in newlinks_offshore.iterrows():
     ax.plot(
         [dfzones.loc[row.r, f'{prefix}x'], dfzones.loc[row.rr, f'{prefix}x']],
         [dfzones.loc[row.r, f'{prefix}y'], dfzones.loc[row.rr, f'{prefix}y']],
-        color=colors[row['trtype']], lw=lw_lines, zorder=1e9,
+        color=colors['VSC'], lw=lw_lines, zorder=1e9,
         alpha=(0.4 if (row.r in offshore and row.rr in offshore) else 1),
     )
 ## Legend
@@ -437,10 +447,10 @@ ax.legend(
 
 ## Formatting
 ax.axis('off')
-savepath = os.path.join(
+figpath = os.path.join(
     reeds.io.reeds_path, 'docs', 'source', 'figs', 'docs',
     'transmission-offshore.png'
 )
-plt.savefig(savepath)
+plt.savefig(figpath)
 if interactive:
     plt.show()

--- a/docs/source/plotting_scripts/maps.py
+++ b/docs/source/plotting_scripts/maps.py
@@ -152,12 +152,29 @@ cmap = {
 }
 
 offset = {
+    'r': {
+        'MO_SE': (0,-1.5e5),
+        'MO_SPP': (0,0.5e5),
+        'MO_MISO': (0,-0.1e5),
+        'NY_LI': (1e5,0),
+        'NY_NYC': (1.5e5,-0.5e5),
+        'ND_MISO': (0,0.5e5),
+        'ND_SPP': (0,-0.5e5),
+        'AR_SPP': (0,1e5),
+        'TX_N': (0,-0.5e5),
+        'NY_W': (-0.8e5,-0.8e5),
+        'VA_W': (0,-0.5e5),
+        'NJ': (0,-0.5e5),
+        'IL_MISO': (0,-0.2e5),
+        'CA_SE': (0,-0.2e5),
+        'FL_S': (-0.1e5,0.1e5),
+    },
     'transreg': {
         'WestConnect': (0,-1e5),
     },
     'transgrp': {
-        'MISO_Central': (-1e5,-2e5),
-        'SPP_North': (1e5,0),
+        'MISO_Central': (1e5,-1e5),
+        'SPP_North': (0,0),
         'CAISO': (-0.1e5,-0.5e5),
         'NorthernGrid_East': (0,-1e5),
         'WestConnect_North': (0,-1e5),
@@ -215,19 +232,28 @@ for level in dfmap:
                 np.array([row.geometry.centroid.x, row.geometry.centroid.y])
                 + np.array(offset.get(level, {}).get(r, (0,0)))
             )
-            ax.annotate(
-                r.replace('_','\n'),
-                (x, y),
-                ha='center', va='center', weight='bold',
-                size={'r':7, 'hurdlereg':7, 'st':10}.get(level,11),
-                color='k', zorder=1e11,
-                path_effects=[pe.withStroke(linewidth=1.5, foreground='w', alpha=1)]
-            )
+            for i, (c, a) in enumerate([('k',1), (colors[r], 0.6)]):
+                if i == 1 and level != 'r':
+                    continue
+                ax.annotate(
+                    (r if level == 'r' else r.replace('_','\n')),
+                    (x, y),
+                    ha='center', va='center', weight='bold',
+                    size={'r':7, 'hurdlereg':7, 'st':10}.get(level,11),
+                    color=c, zorder=1e11+i, alpha=a,
+                    path_effects=(
+                        [pe.withStroke(linewidth=1.5, foreground='w', alpha=(1 if i == 0 else 0))]
+                    ),
+                )
     if label_zones.get(level, True):
         for r, row in dfmap['r'].iterrows():
+            x, y = (
+                np.array([row.geometry.centroid.x, row.geometry.centroid.y])
+                + np.array(offset.get('r', {}).get(r, (0,0)))
+            )
             ax.annotate(
                 r,
-                (row.geometry.centroid.x, row.geometry.centroid.y),
+                (x, y),
                 ha='center', va='center', size=6, weight='normal',
                 color='C7', zorder=1e10,
                 path_effects=[pe.withStroke(linewidth=0.7, foreground='w', alpha=1)]
@@ -245,7 +271,7 @@ for level in dfmap:
     )
     plt.savefig(
         os.path.join(savepath, savename+'.png'),
-        transparent=True,
+        transparent=True, dpi=600,
         bbox_inches='tight',
     )
     plt.show()

--- a/inputs/transmission/README.md
+++ b/inputs/transmission/README.md
@@ -52,7 +52,7 @@ Calculated using the [TSC](https://github.nrel.gov/pbrown/TSC) model as describe
     ```python
     import reeds
     ## GSw_ZoneSet can be any of the supported zone resolutions listed in the `GSw_ZoneSet` row of `cases.csv`
-    GSw_ZoneSet = 'z134'
+    GSw_ZoneSet = 'z90'
     reeds.inputs.get_itls(GSw_ZoneSet=GSw_ZoneSet)
     ```
 


### PR DESCRIPTION
## Summary

This PR updates some of the zone-map figures in the docs for 90-zone resolution, matching the current defaults after #134.

## Technical details <!-- if any, otherwise delete -->

### Implementation notes <!-- if any, otherwise delete -->

- Added some tweaks to `maps.py` to reduce label overlap in the 90-zone map

### Known incompatibilities <!-- if any, otherwise delete -->

- Some of the maps in the docs still have the old zone outlines, but they're pretty inconspicuous and (to me at least) don't seem to warrant a global update. My plan is just to switch them to state outlines the next time we need to update the plots (e.g. the next time we update the supply curves, transmission costs, etc.).

## Validation, testing, and comparison report(s)

- Only figures and .md files were modified (aside from the single `maps.py` used to generate the new maps), so I didn't run any tests.

## Checklist for author
<!-- Fill out before requesting review -->

### Details to double-check
<!-- Delete or ~~strikethrough~~ if not relevant for this PR -->
- [x] Documentation updated if necessary

### General information to guide review
<!-- These do not need to be checked to merge, but if unchecked, a deeper level of review may be required -->
- [x] Zero impact on results of default case
- [x] No large data file(s) added/modified
- [x] No substantive impact on runtime for full-US reference case
- [x] No substantive impact on folder size for full-US reference case
- [x] No change to process flow (runreeds.py, reeds/core/solve/solve.py)
- [x] No change to code organization
- [x] No change to package requirements (environment.yml or Project.toml)
