### PR TITLE
Add backwards compatibility for older versions of GAMS

### DIFF
--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -134,8 +134,12 @@ When creating the `reeds` environment locally, you might run into an SSL error t
 
 
 ### GAMS Configuration
-NLR uses GAMS versions 51.3.0 and 49.6.0; however, older versions might also work. A valid GAMS license must be installed.
 
+ReEDS is actively developed for GAMS versions ≥51.3.0 and is backwards-compatible without modification for GAMS versions ≥44.2.0.
+To use GAMS versions back to 34.3.0, revert to an older version of `gdxpds` by running `pip install gdxpds==1.4.0` within the `reeds` conda environment.
+ReEDS compatibility with GAMS versions older than 34.3.0 is not tested or actively supported.
+
+A valid GAMS license must be installed.
 For more information on getting a trial license for GAMS, see the [FAQ](faq.md#table-of-contents)
 
 1. Install GAMS: [https://www.gams.com/download/](https://www.gams.com/download/)

--- a/postprocessing/retail_rate_module/calculate_historical_capex.py
+++ b/postprocessing/retail_rate_module/calculate_historical_capex.py
@@ -44,18 +44,29 @@ def get_historical_units(inputs_case):
 
     return init_cap
 
+
+def read_from_inputs_gdx(case, key) -> pd.DataFrame:
+    """
+    Read the provided key from inputs.gdx, with backwards compatibility
+    for older gdxpds versions (which return a dictionary instead of a dataframe).
+
+    Args:
+        case: filepath to ReEDS run folder OR to inputs_case
+        key: name of parameter in inputs.gdx file
+    """
+    fpath = os.path.join(reeds.io.standardize_case(case), 'inputs_case', 'inputs.gdx')
+    df = gdxpds.to_dataframe(fpath, key)
+    if isinstance(df, dict):
+        df = df[key]
+    return df
+
+
 def get_earliest_cap_costs(inputs_case):
     # Read national capital costs and get
     # the earliest values for each tech
-    cost_cap = gdxpds.to_dataframe(
-        os.path.join(inputs_case, 'inputs.gdx'),
-        'cost_cap',
-    )
+    cost_cap = read_from_inputs_gdx(inputs_case, 'cost_cap')
     cost_cap.i = cost_cap.i.str.lower()
-    cost_cap_energy = gdxpds.to_dataframe(
-        os.path.join(inputs_case, 'inputs.gdx'),
-        'cost_cap_energy',
-    )
+    cost_cap_energy = read_from_inputs_gdx(inputs_case, 'cost_cap_energy')
     cost_cap_energy.i = cost_cap_energy.i.str.lower()
     cost_cap = (
         pd.concat([cost_cap, cost_cap_energy])
@@ -72,10 +83,7 @@ def get_earliest_cap_costs(inputs_case):
 
     # Read regional capital cost multipliers and
     # get the earliest values for each tech and region
-    cost_cap_mult = gdxpds.to_dataframe(
-        os.path.join(inputs_case, 'inputs.gdx'),
-        'cost_cap_fin_mult_out',
-    )
+    cost_cap_mult = read_from_inputs_gdx(inputs_case, 'cost_cap_fin_mult_out')
     cost_cap_mult.i = cost_cap_mult.i.str.lower()
     cost_cap_mult['t'] = cost_cap_mult['t'].astype(int)
     cost_cap_mult = cost_cap_mult.rename(
@@ -101,10 +109,7 @@ def get_earliest_cap_costs(inputs_case):
     # Read capital costs for technologies whose capital costs
     # are included in their supply curves and attach them
     # to the dataframe of all capital costs
-    rsc_dat = gdxpds.to_dataframe(
-        os.path.join(inputs_case, 'inputs.gdx'),
-        'rsc_dat',
-    )
+    rsc_dat = read_from_inputs_gdx(inputs_case, 'rsc_dat')
     rsc_dat.i = rsc_dat.i.str.lower()
     cost_cap_rsc = (
         rsc_dat.loc[~rsc_dat.i.isin(cost_cap_earliest['i'])]

--- a/reeds/core/setup/b_inputs.gms
+++ b/reeds/core/setup/b_inputs.gms
@@ -73,11 +73,9 @@ $include inputs_case%ds%scalars.txt
 *==========================
 
 * Written by h5_to_gdx.py
-$include autocode%ds%b_declare_sets.gms
-$include autocode%ds%b_declare_parameters.gms
 $gdxin inputs_case%ds%inputs_0.gdx
-$include autocode%ds%b_load_sets.gms
-$include autocode%ds%b_load_parameters.gms
+$include autocode%ds%b_declare_load_sets.gms
+$include autocode%ds%b_declare_load_parameters.gms
 $gdxin
 
 set land(r) "land-based (not offshore) zones" ;

--- a/reeds/input_processing/h5_to_gdx.py
+++ b/reeds/input_processing/h5_to_gdx.py
@@ -76,13 +76,13 @@ def sort_primary_first(declarations:list):
     return writelist
 
 
-def write_declaration(
+def write_declare_and_load(
     case:str|Path,
     declarations:list,
     gamstype:Literal['set','parameter'],
 ):
     """
-    Write GAMS code to declare sets/parameters before loading them from a .gdx file
+    Write GAMS code to declare sets/parameters and load them from a .gdx file
     """
     ## Get aliases so we can define them after the parent is defined
     aliases = pd.read_csv(
@@ -94,33 +94,15 @@ def write_declaration(
         writelist = sort_primary_first(declarations)
     else:
         writelist = declarations
-    fpath = Path(case, 'autocode', f'b_declare_{gamstype}s.gms')
-    with open(fpath, 'w') as f:
-        if len(writelist):
-            for line in writelist:
-                f.write(f'{gamstype} {line} ;\n')
-                name = line.split('(')[0]
-                for alias in aliases.get([name], []):
-                    f.write(f'alias({name},{alias}) ;\n')
-    print(f'Wrote {fpath}')
-
-
-def write_gdxread(
-    case:str|Path,
-    declarations:list,
-    gamstype:Literal['set','parameter'],
-):
-    """
-    Write GAMS code to read sets/parameters from .gdx file
-    """
-    ## Need to write primary sets before subsets
-    if gamstype == 'set':
-        writelist = sort_primary_first(declarations)
-    else:
-        writelist = declarations
-    fpath = Path(case, 'autocode', f'b_load_{gamstype}s.gms')
+    fpath = Path(case, 'autocode', f'b_declare_load_{gamstype}s.gms')
     with open(fpath, 'w') as f:
         for line in writelist:
+            ## Declare
+            f.write(f'{gamstype} {line} ;\n')
+            name = line.split('(')[0]
+            for alias in aliases.get([name], []):
+                f.write(f'alias({name},{alias}) ;\n')
+            ## Load
             key = line.split('(')[0]
             f.write(f'$loadDCR {key} = {key}\n')
     print(f'Wrote {fpath}')
@@ -165,10 +147,8 @@ def main(case, overwrite=True, verbose=1):
         gdx.write(gdxpath)
         print(f'Wrote inputs.h5 to {gdxpath}')
     ## Write GAMS code to declare and load the sets/parameters
-    write_declaration(case, declare_sets, 'set')
-    write_declaration(case, declare_parameters, 'parameter')
-    write_gdxread(case, declare_sets, 'set')
-    write_gdxread(case, declare_parameters, 'parameter')
+    write_declare_and_load(case, declare_sets, 'set')
+    write_declare_and_load(case, declare_parameters, 'parameter')
 
 
 #%% Procedure

--- a/reeds/io.py
+++ b/reeds/io.py
@@ -4,6 +4,7 @@ import sys
 import re
 import datetime
 import h5py
+import ctypes
 import inspect
 import numpy as np
 import pandas as pd
@@ -1882,7 +1883,7 @@ def write_output_to_h5(
             print(f'{key} dataframe is empty, so it was not written to {filepath}')
         return dfwrite
     ## Drop the Value column if it's a set
-    if pd.api.types.is_string_dtype(dfwrite.Value):
+    if pd.api.types.is_string_dtype(dfwrite.Value) or isinstance(dfwrite.Value.values[0], ctypes.c_bool):
         dfwrite.drop("Value", axis=1, inplace=True)
     ## Make column names unique (necessary if '*' is overused)
     make_columns_unique(dfwrite)


### PR DESCRIPTION
## Summary

This PR addresses #149 by supporting GAMS versions back to 34.3.0 (the oldest available on kestrel).

## Technical details <!-- if any, otherwise delete -->

### Implementation notes <!-- if any, otherwise delete -->

Errors arising on older GAMS versions are described at https://github.com/RMI/ReEDS-CEPM/pull/33. In brief:
- As of #61, we were writing the set/parameter declaration in two steps, declaring all the sets/parameters first and then loading them afterward.
  - Older GAMS versions do not support loading sets after they have been used as domains for subsets, so this approach works on GAMS ≥51 but fails on GAMS 44 (and probably others)
- Here, we instead load sets/parameters immediately after they're declared, avoiding the issue on older GAMS versions

I added a note to `setup.md` describing the support level for different GAMS versions.

### Issues resolved <!-- if any, otherwise delete -->

#149

## Validation, testing, and comparison report(s)

I ran tests on kestrel with GAMS 44.2.0 and 34.3.0 (reverting to gdxpds=1.4.0 as noted in `setup.md` for the 34.3.0 test) and both worked.

Zero change for the Pacific test case: [results-v20260814_mainM0_Pacific,v20260814_gams34M0_Pacific.pptx](https://github.com/user-attachments/files/31081683/results-v20260814_mainM0_Pacific.v20260814_gams34M0_Pacific.pptx)


## Checklist for author
<!-- Fill out before requesting review -->

### Details to double-check
<!-- Delete or ~~strikethrough~~ if not relevant for this PR -->
- [x] Charge code provided to reviewers
- [x] Included comparison reports for appropriate test cases
- [x] Documentation updated if necessary
- [x] Code formatting standardized <!-- Coding conventions: https://reeds-model.github.io/ReEDS/developer_best_practices.html#coding-standards-and-conventions -->
- [x] Reusable functions used where possible instead of copy/pasted code

### General information to guide review
<!-- These do not need to be checked to merge, but if unchecked, a deeper level of review may be required -->
- [x] Zero impact on results of default case
- [x] No large data file(s) added/modified
- [x] No substantive impact on runtime for full-US reference case
- [x] No substantive impact on folder size for full-US reference case
- [x] No change to process flow (runreeds.py, reeds/core/solve/solve.py)
- [x] No change to code organization
- [ ] No change to package requirements (support extended back to GAMS 34)

#### Did you use LLM tools (chatbot or copilot) in the preparation of this PR? If so, describe how

No