### PR TITLE
Add price-weighted capacity credit output

### DIFF
--- a/postprocessing/single_case_plots.py
+++ b/postprocessing/single_case_plots.py
@@ -827,6 +827,7 @@ if not int(sw.GSw_PRM_CapCredit):
         'stress_top10_netload',
         'stress_top10_load',
         'stress_bottom10_vregen',
+        'stress_price_weighted',
     ]:
         savename = f"plot_stress_cf-{level}-{metric}.png"
         try:

--- a/reeds/reedsplots.py
+++ b/reeds/reedsplots.py
@@ -5532,7 +5532,7 @@ def stress_mix_label(case, metric):
     elif metric == 'stress_mean':
         xlabel = 'Stress mean gen'
     elif metric == 'stress_price_weighted':
-        xlabel = 'Stress price-weighted gen'
+        xlabel = 'Stress: price-weighted gen'
     elif ('top' in metric) or ('bottom' in metric):
         direction = ('top' if 'top' in metric else 'bottom')
         xlabel = "Stress: {} {} {} hours".format(

--- a/reeds/reedsplots.py
+++ b/reeds/reedsplots.py
@@ -5815,7 +5815,7 @@ def plot_stress_mix(
 def plot_stress_cf(
     case:str|Path,
     level='transreg',
-    metric='stress_top10_netload',
+    metric='stress_price_weighted',
     include_rep=True,
     figwidth=1.2,
     figheight=1.2,

--- a/reeds/reedsplots.py
+++ b/reeds/reedsplots.py
@@ -5531,6 +5531,8 @@ def stress_mix_label(case, metric):
         xlabel = f"Rep {metric.split('_')[1]} gen"
     elif metric == 'stress_mean':
         xlabel = 'Stress mean gen'
+    elif metric == 'stress_price_weighted':
+        xlabel = 'Stress price-weighted gen'
     elif ('top' in metric) or ('bottom' in metric):
         direction = ('top' if 'top' in metric else 'bottom')
         xlabel = "Stress: {} {} {} hours".format(

--- a/reeds/reedsplots.py
+++ b/reeds/reedsplots.py
@@ -5304,7 +5304,7 @@ def separate_charge_discharge(df):
 
 def check_metric(metric):
     allowed = (
-        r'(cap|rep_mean|stress_(mean|(max|min|top\d+|bottom\d+)_(gen|load|netload|price|vregen)))'
+        r'(cap|rep_mean|stress_(mean|price_weighted|(max|min|top\d+|bottom\d+)_(gen|load|netload|price|vregen)))'
     )
     if not re.match(allowed, metric):
         raise ValueError(f"metric={metric} must match {allowed}")

--- a/reeds/reedsplots.py
+++ b/reeds/reedsplots.py
@@ -5444,6 +5444,23 @@ def get_cap_rep_stress_mix(
                     .divide(gen_h_stress.groupby('t').h.unique().map(len), axis=0)
                 )
 
+            elif key == 'stress_price_weighted':
+                ## Price-weighted average generation across all stress hours:
+                ## sum_h(gen*price) / sum_h(price)
+                price_long = price_stress.stack('r').rename('price').reset_index()
+                price_sum = price_long.groupby(['t','r'], as_index=False).price.sum()
+                gen_price = gen_h_stress.merge(price_long, on=['t','r','h'], how='left')
+                gen_price['price'] = gen_price['price'].fillna(0)
+                gen_price['gen_x_price'] = gen_price.MW * gen_price.price
+                numer = gen_price.groupby(['t','i','r'], as_index=False).gen_x_price.sum()
+                df = numer.merge(price_sum, on=['t','r'], how='left')
+                df['MW'] = df.gen_x_price / df.price
+                df = df.set_index(['t','i','r']).MW.unstack('r')
+                ## Guard against exact-cancellation division by zero (positive/negative hourly
+                ## prices summing to ~0 while gen_x_price is nonzero); NaN (0/0) is also possible
+                ## and both should collapse to 0
+                df = df.replace([np.inf, -np.inf], np.nan).fillna(0)
+
             ## Generation during regional max hours
             elif key.startswith('stress'):
                 direction = ('top' if 'top' in key else 'bottom')

--- a/reeds/reedsplots.py
+++ b/reeds/reedsplots.py
@@ -5849,6 +5849,9 @@ def plot_stress_cf(
     techs = dfstress['cap'].index.tolist()
     capcredit = (dfstress[metric] / dfstress['cap']).reindex(techs) * 100
     repfraction = (dfstress['rep_mean'] / dfstress['cap']).reindex(techs) * 100
+    ## Replace and INF values with NaN (can occur due to small-number division)
+    capcredit = capcredit.replace([np.inf, -np.inf], np.nan)
+    repfraction = repfraction.replace([np.inf, -np.inf], np.nan)
     ### Set up plot
     dfmap = reeds.io.get_dfmap(case)
     regions = dfmap[level].bounds.minx.sort_values().index
@@ -5896,7 +5899,13 @@ def plot_stress_cf(
                     )
             _ax.set_xlabel(None)
     ## Formatting
-    _ax.set_ylim(0, 100)
+    finite_vals = np.concatenate([
+        capcredit.values[np.isfinite(capcredit.values)],
+        repfraction.values[np.isfinite(repfraction.values)],
+    ])
+    datamax = finite_vals.max() if finite_vals.size else 0
+    ymax = datamax * 1.02 if datamax > 100 else 100
+    _ax.set_ylim(0, ymax)
     _ax.set_xlim(yearmin, yearmax)
     _ax.yaxis.set_major_locator(mpl.ticker.MultipleLocator(50))
     _ax.yaxis.set_minor_locator(mpl.ticker.MultipleLocator(10))


### PR DESCRIPTION
## Summary
This pull request builds on #171 to add a price-weighted variant of the capacity-credit-like plots for using stress periods.  We have an option that looks at the top 10 hours, but this instead looks at the all hours and weights them by their price.  For regions that have less than 10 hours with a meaningful price, this will mean the ~$0 periods won't get included.  Here's an example from Alabama for 2050, which only has 7 higher priced hours (the % values show how much of the price weight occurs on that day):

<img width="3543" height="2391" alt="AL_2050" src="https://github.com/user-attachments/assets/1e37d61e-616a-454e-970b-3e2b44c0ba45" />

For other regions that have more than 10 hours, this allows all of those hours get captured.  For example, here is the CA_LA region for 2050:

<img width="3542" height="2391" alt="CA_LA_2050" src="https://github.com/user-attachments/assets/bc412d94-e4e1-4114-8a99-7b1dd72b7948" />

It also changes the function's default to this new method because I think it is the most accurate way to estimate a marginal capacity credit.

## Technical details <!-- if any, otherwise delete -->

### Implementation notes <!-- if any, otherwise delete -->
I added a filter for infinity values in the capacity-credit division (gen / cap).  There is sometimes a region with zero capacity but a tiny nonzero residual in generation (~1e-16), which creates an infinity value. This is was present for any metric, and I don't think it impacted them, but filtering it out means it won't cause unintended issues.

I also changed the ymax value of the plots to be dynamic because the capacity credit can go above 100% for some technologies (we measure capacity credit using net summer capacity, and net winter capacity can be meaningfully higher than net summer).

## Validation, testing, and comparison report(s)
The output for this new metric looks like this (drawn from the run performed for #176):

<img width="1443" height="589" alt="stress_price_weighted_padded" src="https://github.com/user-attachments/assets/652bbf7a-cbb6-43ff-97bd-82cad815010f" />

## Checklist for author
<!-- Fill out before requesting review -->

### Details to double-check
<!-- Delete or ~~strikethrough~~ if not relevant for this PR -->
- [ ] Charge code provided to reviewers
- ~~[ ] Included comparison reports for appropriate test cases~~
- ~~[ ] Documentation updated if necessary~~
  <!--
  - model_documentation.md: High-level description of default model behavior
  - user_guide.md: User/developer-facing description of model switches and input files
  - faq.md: Limitations, caveats, and known issues
  - postprocessing_tools.md: User/developer-facing description of scripts in postprocessing folder
  - README.md files: User/developer facing description of individual input folders
  -->
- [x] Code formatting standardized <!-- Coding conventions: https://reeds-model.github.io/ReEDS/developer_best_practices.html#coding-standards-and-conventions -->
- [x] Reusable functions used where possible instead of copy/pasted code

### General information to guide review
<!-- These do not need to be checked to merge, but if unchecked, a deeper level of review may be required -->
- [x] Zero impact on results of default case
- [x] No large data file(s) added/modified
- [x] No substantive impact on runtime for full-US reference case
- [x] No substantive impact on folder size for full-US reference case
- [x] No change to process flow (runreeds.py, reeds/core/solve/solve.py)
- [x] No change to code organization
- [x] No change to package requirements (environment.yml or Project.toml)

#### Did you use LLM tools (chatbot or copilot) in the preparation of this PR? If so, describe how
Yes — I implemented this with Claude (I used plan mode for design, I asked it to stop for my review after it completed each step, and I used to for tracing for the inf values).

### Tag points of contact here if you would like additional review of the relevant parts of the model
<!-- Model dimensions -->
<!-- - [ ] County resolution: @louisaserpe -->
<!-- - [ ] Demand data: @ahamilton5 -->
<!-- - [ ] Emissions: @atpham88 -->
<!-- - [ ] Financial calculations: @wesleyjcole -->
<!-- - [ ] FINITO: @merveturan or @cavraam -->
<!-- - [ ] Hybrids: @aschleif -->
<!-- - [ ] Monte Carlo: @bsergi -->
<!-- - [ ] Sparse chronology or interday diurnal storage: @Yunzhi-Chen -->
<!-- - [ ] State policies: @wesleyjcole or @aschleif -->
<!-- - [ ] Stress periods, resource adequacy, or ReEDS2PRAS/Julia: @patrickbrown4 -->
<!-- - [ ] Supply curves, hourlize, reeds_to_rev: @bsergi -->
<!-- - [ ] Time resolution: @patrickbrown4 -->
<!-- - [ ] Water cooling: @jcarag or @stuartcohen8 -->

<!-- Pre/Postprocessing -->
<!-- - [ ] Dispatch mode (run_pcm.py): @patrickbrown4 -->
<!-- - [ ] Github actions: @kennedy-mindermann -->
<!-- - [ ] Health impacts: @bsergi -->
<!-- - [ ] Input data structure and processing: @kodiobika -->
<!-- - [ ] Interactive plots (bokeh, vizit): @mmowers -->
<!-- - [ ] Land use: @bsergi -->
<!-- - [ ] R2X: @pesap -->
<!-- - [ ] Retail rates: @wesleyjcole -->
<!-- - [ ] Static plots (single_case_plots.py, compare_cases.py): @patrickbrown4 -->
<!-- - [ ] Tableau: @ahamilton5 -->
<!-- - [ ] Technology value (reValue, valuestreams.py): @mmowers -->

<!-- Technologies -->
<!-- - [ ] Batteries: @wesleyjcole -->
<!-- - [ ] EV managed charging (EVMC): @Max-Vanatta -->
<!-- - [ ] Fossil, CCS, or DAC: @mbrown1 -->
<!-- - [ ] Geothermal: @shashwatsharma24 -->
<!-- - [ ] Hydropower or PSH: @stuartcohen8 -->
<!-- - [ ] Hydrogen: @bsergi -->
<!-- - [ ] Nuclear: @wesleyjcole -->
<!-- - [ ] Solar: @wesleyjcole -->
<!-- - [ ] Transmission: @patrickbrown4 -->
<!-- - [ ] Wind: @mmowers -->
