### PR TITLE
Copy MGA solver file if used

### DIFF
--- a/reeds/input_processing/copy_files.py
+++ b/reeds/input_processing/copy_files.py
@@ -954,6 +954,10 @@ def write_miscellaneous_files(
     case = Path(inputs_case).parent
     optfile = reeds.io.get_optfile(case)
     shutil.copy(Path(reeds_path, 'reeds', 'solver', optfile), case)
+    ## If using MGA, copy its solver file too
+    if float(sw.GSw_MGA_CostDelta) > 0:
+        optfile = reeds.io.get_optfile(case, GSw_gopt=sw.GSw_gopt_mga)
+        shutil.copy(Path(reeds_path, 'reeds', 'solver', optfile), case)
 
     ### Parsed switches
     pd.DataFrame(

--- a/reeds/io.py
+++ b/reeds/io.py
@@ -666,6 +666,10 @@ def get_switches_base(case=None, **kwargs):
             index_col=0,
             header=None,
         ).squeeze(1)
+    ### Overwrite values with keyword arguments if provided
+    for key, value in kwargs.items():
+        if key in sw.keys():
+            sw[key] = value
     return sw
 
 
@@ -703,7 +707,7 @@ def get_switches(case=None, **kwargs):
     that is not a valid switch name, it is ignored.
     """
     case = standardize_case(case)
-    sw = get_switches_base(case)
+    sw = get_switches_base(case, **kwargs)
     ### Resource-adequacy-specific switches
     try:
         fpath_asw = os.path.join(


### PR DESCRIPTION
## Summary

In #36, I forgot to copy the solver file specified by the `GSw_gopt_mga` switch to the case folder. So runs using MGA and `GSw_gopt_mga != GSw_gopt` were not finding the specified solver file and reverting to default solver settings, likely leading to slow performance with MGA. This PR copies the solver file specified by `GSw_gopt_mga` when using MGA.

## Validation, testing, and comparison report(s)

I verified that the default MGA solver file (`cplex.op3`) now shows up in the case folder for the Pacific_MGA test case and not for a non-MGA test case.

The warning observed in `gamslog.txt` for the Pacific_MGA case on the main branch (`*** Error Cannot open parameter file "/Users/pbrown/github2/ReEDS/runs/v20260825_mainM0_Pacific_MGA/cplex.op3"`) goes away with this change.

Zero change for the Pacific test case: [results-v20260825_mainM0_Pacific,v20260826_mgaM0_Pacific.pptx](https://github.com/user-attachments/files/31432834/results-v20260825_mainM0_Pacific.v20260826_mgaM0_Pacific.pptx)

## Checklist for author
<!-- Fill out before requesting review -->

### Details to double-check
<!-- Delete or ~~strikethrough~~ if not relevant for this PR -->
- [x] Charge code provided to reviewers
- [x] Included comparison reports for appropriate test cases
- [x] Code formatting standardized <!-- Coding conventions: https://reeds-model.github.io/ReEDS/developer_best_practices.html#coding-standards-and-conventions -->
- [x] Reusable functions used where possible instead of copy/pasted code

### General information to guide review
<!-- These do not need to be checked to merge, but if unchecked, a deeper level of review may be required -->
- [x] Zero impact on results of default case
- [x] No large data file(s) added/modified
- [x] No substantive impact on runtime for full-US reference case
- [x] No substantive impact on folder size for full-US reference case
- [x] No change to process flow (runreeds.py, reeds/core/solve/solve.py)
- [x] No change to code organization
- [x] No change to package requirements (environment.yml or Project.toml)

#### Did you use LLM tools (chatbot or copilot) in the preparation of this PR? If so, describe how

No