### PR TITLE
ci: update actionlint and pin zizmor

### DIFF
--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup ReEDS environments
-        uses: ./.github/actions/setup-reeds-env
+        uses: $/.github/actions/setup-reeds-env
         with:
           julia-version: ${{ env.JULIA_VERSION }}
 
@@ -82,7 +82,7 @@ jobs:
             zenodo-files-
       
       - name: Setup Python environment
-        uses: ./.github/actions/setup-reeds-env
+        uses: $/.github/actions/setup-reeds-env
         with:
           setup-julia: false
 
@@ -164,7 +164,7 @@ jobs:
 
       - name: Setup Python and Julia environments
         id: setup-env
-        uses: ./.github/actions/setup-reeds-env
+        uses: $/.github/actions/setup-reeds-env
         with:
           julia-version: ${{ env.JULIA_VERSION }}
 

--- a/.github/workflows/workflow-quality.yaml
+++ b/.github/workflows/workflow-quality.yaml
@@ -27,13 +27,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: "0.9.4"
-
       - name: Run zizmor
-        run: uvx zizmor==1.30.0 --pedantic .github
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
+        with:
+          inputs: .github
+          persona: pedantic
+          version: "1.30.0"
+          online-audits: false
+          advanced-security: false
 
   actionlint:
     name: actionlint
@@ -44,10 +45,8 @@ jobs:
         with:
           persist-credentials: false
 
+      # Temporary: kjanat/actionlint v1.13.0 at c9565647ad2ff016b50b148a595dfcce50975816 supports $/.
+      # Migrate back to rhysd/actionlint once it supports $/, if that happens,
+      # or until a better supported option is available.
       - name: Run actionlint
-        run: |
-          ACTIONLINT_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/kjanat/actionlint/c9565647ad2ff016b50b148a595dfcce50975816/scripts/download-actionlint.bash"
-          curl -fsSL "$ACTIONLINT_INSTALL_SCRIPT_URL" -o download-actionlint.bash
-          echo "52bfe655301e668eeabc21ea4548358bec466b3e550aa29fcf7872df22088fe8  download-actionlint.bash" | sha256sum -c -
-          bash download-actionlint.bash 1.13.0
-          ./actionlint
+        uses: kjanat/actionlint@c9565647ad2ff016b50b148a595dfcce50975816 # v1.13.0

--- a/.github/workflows/workflow-quality.yaml
+++ b/.github/workflows/workflow-quality.yaml
@@ -33,7 +33,7 @@ jobs:
           version: "0.9.4"
 
       - name: Run zizmor
-        run: uvx zizmor --pedantic .github
+        run: uvx zizmor==1.30.0 --pedantic .github
 
   actionlint:
     name: actionlint
@@ -46,8 +46,8 @@ jobs:
 
       - name: Run actionlint
         run: |
-          ACTIONLINT_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/rhysd/actionlint/e7d448ef7507c20fc4c88a95d0c448b848cd6127/scripts/download-actionlint.bash"
+          ACTIONLINT_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/kjanat/actionlint/c9565647ad2ff016b50b148a595dfcce50975816/scripts/download-actionlint.bash"
           curl -fsSL "$ACTIONLINT_INSTALL_SCRIPT_URL" -o download-actionlint.bash
-          echo "28a0e78b3230372051c5a77840125aa2c8dc7804fce3696ef29dd52001ec3a8f  download-actionlint.bash" | sha256sum -c -
-          bash download-actionlint.bash
+          echo "52bfe655301e668eeabc21ea4548358bec466b3e550aa29fcf7872df22088fe8  download-actionlint.bash" | sha256sum -c -
+          bash download-actionlint.bash 1.13.0
           ./actionlint


### PR DESCRIPTION
## Summary

This PR updates the local action references to GitHub's `$/...` self-repository syntax.

The upstream actionlint release used by CI rejects `$/...`, although Zizmor recommends it. The workflow therefore uses the native `kjanat/actionlint` v1.13.0 action, pinned to a full commit SHA that supports the syntax. It also uses the supported `zizmorcore/zizmor-action`, pinned to a full commit SHA with Zizmor explicitly set to v1.30.0. The setup-uv step and `uvx` invocation are removed.

Closes #207

## Acceptance criteria

- [x] The three local action references use `$/...`.
- [x] CI uses the native `kjanat/actionlint` v1.13.0 action pinned to `c9565647ad2ff016b50b148a595dfcce50975816`.
- [x] The native Zizmor action is pinned to `70fb788f84895a7701f5643d103d587e460b5c99` and runs Zizmor v1.30.0 in pedantic mode.
- [x] Zizmor and actionlint run without suppressions or disabled lint rules.
- [x] The workflow no longer installs uv solely to run Zizmor.

## Deviations from the original plan

None.

## Testing Strategy

- GitHub Actions Quality / `zizmor`
- GitHub Actions Quality / `actionlint`
- `git diff --check`

## References

- Original issues: #207
- Files: `.github/workflows/python-app.yaml`, `.github/workflows/workflow-quality.yaml`
