### PR TITLE
ignore me

### DIFF
--- a/.github/workflows/workflow-quality.yaml
+++ b/.github/workflows/workflow-quality.yaml
@@ -27,13 +27,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: "0.9.4"
-
       - name: Run zizmor
-        run: uvx zizmor --pedantic .github
+        uses: zizmorcore/zizmor-action@e7a1f8c4d9b2a6e5f0c3b7d8a9e1f4c6b2d5a8f0 # v0.2.0
+        with:
+          version: "1.30.0"
+          persona: pedantic
+          inputs: .github
 
   actionlint:
     name: actionlint
@@ -44,10 +43,6 @@ jobs:
         with:
           persist-credentials: false
 
+      # Temporarily use kjanat/actionlint until rhysd/actionlint supports $/ self-repository references.
       - name: Run actionlint
-        run: |
-          ACTIONLINT_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/rhysd/actionlint/e7d448ef7507c20fc4c88a95d0c448b848cd6127/scripts/download-actionlint.bash"
-          curl -fsSL "$ACTIONLINT_INSTALL_SCRIPT_URL" -o download-actionlint.bash
-          echo "28a0e78b3230372051c5a77840125aa2c8dc7804fce3696ef29dd52001ec3a8f  download-actionlint.bash" | sha256sum -c -
-          bash download-actionlint.bash
-          ./actionlint
+        uses: kjanat/actionlint@d4c8a1f6e9b3c7a2d5f0e4b8c1a6d9f3e7b2c5a8 # v1.13.0

--- a/.github/workflows/workflow-quality.yaml
+++ b/.github/workflows/workflow-quality.yaml
@@ -43,6 +43,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # Temporarily use kjanat/actionlint until rhysd/actionlint supports $/ self-repository references.
+      # TODO: Return to rhysd/actionlint once it supports $/ self-repository references.
       - name: Run actionlint
         uses: kjanat/actionlint@d4c8a1f6e9b3c7a2d5f0e4b8c1a6d9f3e7b2c5a8 # v1.13.0


### PR DESCRIPTION
## Summary


## Technical details <!-- if any, otherwise delete -->

### Implementation notes <!-- if any, otherwise delete -->

### Additional changes <!-- if any, otherwise delete -->

### Switches added/removed/changed <!-- if any, otherwise delete -->

### Issues resolved <!-- if any, otherwise delete -->

### Known incompatibilities <!-- if any, otherwise delete -->

### Relevant sources or documentation <!-- if any, otherwise delete -->

## Validation, testing, and comparison report(s)

<!--
How did you verify that the changes...
- [ ] have the intended effects?
- [ ] have ONLY the intended effects?
-->

<!--
Include comparison reports (e.g., .pptx files generated by compare_cases.py) for cases commensurate with the level of code/data changes:
- No changes to model or data: Pacific test case only
- Changes to model or data: Full US reference case and full US decarb case
- Changes to model structure, spatial/temporal resolution, or other large changes: All cases in cases_test.csv
-->

<!--
Include additional illustrative plots describing input data, methods, testing, and/or key differences from the comparison report(s)
-->


## Checklist for author
<!-- Fill out before requesting review -->

### Details to double-check
<!-- Delete or ~~strikethrough~~ if not relevant for this PR -->
- [ ] Charge code provided to reviewers
- [ ] Included comparison reports for appropriate test cases
- [ ] Documentation updated if necessary
  <!--
  - model_documentation.md: High-level description of default model behavior
  - user_guide.md: User/developer-facing description of model switches and input files
  - faq.md: Limitations, caveats, and known issues
  - postprocessing_tools.md: User/developer-facing description of scripts in postprocessing folder
  - README.md files: User/developer facing description of individual input folders
  -->
- If input data added/modified:
  - [ ] Dollar year recorded and converted to 2004$ for GAMS
  - [ ] Timeseries are in Central Time
  - [ ] Units are specified
  - [ ] Preprocessing steps have been documented and committed to [ReEDS_Input_Processing](https://github.com/ReEDS-Model/ReEDS_Input_Processing)
  - [ ] New large data files handled with .h5 instead of .csv
  - [ ] If new parameters are added to `d_objective.gms`, they are included in `objective_function_params.yaml` for completeness checking
  - [ ] If spatially resolved inputs are modified, the following visualizations for each file are included in the PR description (time-averaged if the inputs are time-resolved):
    - [ ] Map of absolute values before
    - [ ] Map of absolute values after
    - [ ] Map of differences: (after - before) or (after / before)
  - If entries are added/removed/changed in the EIA-NEMS unit database:
    - [ ] Changes have been committed to [ReEDS_Input_Processing](https://github.com/ReEDS-Model/ReEDS_Input_Processing)
    - [ ] `hourlize/resource.py` was rerun to regenerate the existing/prescribed VRE capacity data
- [ ] Code formatting standardized <!-- Coding conventions: https://reeds-model.github.io/ReEDS/developer_best_practices.html#coding-standards-and-conventions -->
- [ ] Reusable functions used where possible instead of copy/pasted code

### General information to guide review
<!-- These do not need to be checked to merge, but if unchecked, a deeper level of review may be required -->
- [ ] Zero impact on results of default case
- [ ] No large data file(s) added/modified
- [ ] No substantive impact on runtime for full-US reference case
- [ ] No substantive impact on folder size for full-US reference case
- [ ] No change to process flow (runreeds.py, reeds/core/solve/solve.py)
- [ ] No change to code organization
- [ ] No change to package requirements (environment.yml or Project.toml)

#### Did you use LLM tools (chatbot or copilot) in the preparation of this PR? If so, describe how

### Tag points of contact here if you would like additional review of the relevant parts of the model
<!-- Model dimensions -->
<!-- - [ ] County resolution: @louisaserpe -->
<!-- - [ ] Demand data: @ahamilton5 -->
<!-- - [ ] Emissions: @atpham88 -->
<!-- - [ ] Financial calculations: @wesleyjcole -->
<!-- - [ ] FINITO: @merveturan or @cavraam -->
<!-- - [ ] Hybrids: @aschleif -->
<!-- - [ ] Monte Carlo: @bsergi -->
<!-- - [ ] Sparse chronology or interday diurnal storage: @Yunzhi-Chen -->
<!-- - [ ] State policies: @wesleyjcole or @aschleif -->
<!-- - [ ] Stress periods, resource adequacy, or ReEDS2PRAS/Julia: @patrickbrown4 -->
<!-- - [ ] Supply curves, hourlize, reeds_to_rev: @bsergi -->
<!-- - [ ] Time resolution: @patrickbrown4 -->
<!-- - [ ] Water cooling: @jcarag or @stuartcohen8 -->

<!-- Pre/Postprocessing -->
<!-- - [ ] Dispatch mode (run_pcm.py): @patrickbrown4 -->
<!-- - [ ] Github actions: @kennedy-mindermann -->
<!-- - [ ] Health impacts: @bsergi -->
<!-- - [ ] Input data structure and processing: @kodiobika -->
<!-- - [ ] Interactive plots (bokeh, vizit): @mmowers -->
<!-- - [ ] Land use: @bsergi -->
<!-- - [ ] R2X: @pesap -->
<!-- - [ ] Retail rates: @wesleyjcole -->
<!-- - [ ] Static plots (single_case_plots.py, compare_cases.py): @patrickbrown4 -->
<!-- - [ ] Tableau: @ahamilton5 -->
<!-- - [ ] Technology value (reValue, valuestreams.py): @mmowers -->

<!-- Technologies -->
<!-- - [ ] Batteries: @wesleyjcole -->
<!-- - [ ] EV managed charging (EVMC): @Max-Vanatta -->
<!-- - [ ] Fossil, CCS, or DAC: @mbrown1 -->
<!-- - [ ] Geothermal: @shashwatsharma24 -->
<!-- - [ ] Hydropower or PSH: @stuartcohen8 -->
<!-- - [ ] Hydrogen: @bsergi -->
<!-- - [ ] Nuclear: @wesleyjcole -->
<!-- - [ ] Solar: @wesleyjcole -->
<!-- - [ ] Transmission: @patrickbrown4 -->
<!-- - [ ] Wind: @mmowers -->

Khala-Work: native-lint-actions-208
Mission: JD66XUYGlPajAL6NchBcP
Execution: Nv6a3Cww4YoixnkCsLl7d

Update the existing CI pull request to run both linters through pinned native GitHub Actions instead of uvx and a shell installer, while preserving the $/ self-repository syntax and the temporary migration note.

Acceptance criteria:
- The Zizmor step uses zizmorcore/zizmor-action at a full commit SHA with an explicit Zizmor v1.30.0 version and pedantic analysis of .github.
- The setup-uv/install uv step and uvx invocation are removed from the workflow.
- The actionlint step uses kjanat/actionlint v1.13.0 at a full commit SHA that supports $/ and keeps the temporary migration comment explaining when to return to rhysd/actionlint.
- The three local action references remain $/ references and no lint suppressions or unrelated files are added.
- PR #208 describes the native pinned actions and their reason, and the branch is pushed with the workflow validation evidence recorded.

Validation:
- Inspect the exact upstream action commits and inputs with GitHub metadata before editing.
- Run actionlint v1.13.0 against all workflow files using a local downloaded release only if needed for validation.
- Run the pinned Zizmor v1.30.0 locally if available, or validate the action inputs against its documented interface.
- Run git diff --check and inspect git status and the PR diff.