### PR TITLE
Additional Class Expansion

### DIFF
--- a/reeds/core/setup/b_inputs.gms
+++ b/reeds/core/setup/b_inputs.gms
@@ -1522,7 +1522,7 @@ $onempty
 parameter capacity_exog(i,v,r,allt)             "--MW-- exogenously specified capacity",
           capacity_exog_energy(i,v,r,allt)      "--MWh-- exogenously specified energy capacity",
           capacity_exog_rsc(i,c,v,r,rscbin,allt)  "--MW-- exogenous (pre-tfirst) capacity for wind-ons and upv",
-          m_capacity_exog(i,v,r,allt)           "--MW-- exogenous power capacity used in the model",
+          m_capacity_exog(i,c,v,r,allt)         "--MW-- exogenous power capacity used in the model",
           m_capacity_exog_energy(i,v,r,allt)    "--MWh-- exogenous energy capacity used in the model",
           geo_cap_exog(i,r)                     "--MW-- existing geothermal capacity"
 /
@@ -1637,9 +1637,11 @@ avail_retire_exog_rsc(i,v,r,t)$[refurbtech(i)$(capacity_exog(i,v,r,t-1) > capaci
 
 avail_retire_exog_rsc(i,v,r,t)$[not initv(v)] = 0 ;
 
-m_capacity_exog(i,v,r,t)$capacity_exog(i,v,r,t) = capacity_exog(i,v,r,t) ;
+m_capacity_exog(i,c,v,r,t)$[i_c(i,c)$capacity_exog(i,v,r,t)] = capacity_exog(i,v,r,t) ;
 m_capacity_exog_energy(i,v,r,t)$capacity_exog_energy(i,v,r,t) = capacity_exog_energy(i,v,r,t) ;
-m_capacity_exog(i,"init-1",r,t)$geo(i) = geo_cap_exog(i,r) ;
+m_capacity_exog(i,c,"init-1",r,t)$[i_c(i,c)$geo(i)] = geo_cap_exog(i,r) ;
+m_capacity_exog(i,c,v,r,t)$sum{rscbin, capacity_exog_rsc(i,c,v,r,rscbin,t) } =
+    sum{rscbin, capacity_exog_rsc(i,c,v,r,rscbin,t) } ;
 
 * We assign the ~1.3 GW of existing csp-ns to upv throughout the model, both in the
 * exogenous and the prescribed capacity, and convert it back to csp-ns when reporting.
@@ -1719,8 +1721,8 @@ $onlisting
 
 parameter inv_distpv(r,t) "--MW-- capacity of distpv that is build in year t (i.e., INV for distpv)" ;
 
-inv_distpv(r,t) = sum{(i,v)$distpv(i),
-                      m_capacity_exog(i,v,r,t) - sum{tt$tprev(t,tt), m_capacity_exog(i,v,r,tt) }
+inv_distpv(r,t) = sum{(i,c,v)$[distpv(i)$i_c(i,c)],
+                      m_capacity_exog(i,c,v,r,t) - sum{tt$tprev(t,tt), m_capacity_exog(i,c,v,r,tt) }
                      } ;
 
 set valcap(i,v,r,t)            "i, v, r, and t combinations that are allowed for capacity",
@@ -1765,9 +1767,9 @@ m_required_prescriptions(i,v,r,t)$tmodel_new(t)
 
 m_required_prescriptions(i,v,r,t)$[tmodel_new(t)
                                    $(sum{tt$[yeart(t)>=yeart(tt)], prescribedrsc(i,v,r,tt) }
-                                     or m_capacity_exog(i,v,r,t) )$rsc_i(i)]
+                                     or sum{c, m_capacity_exog(i,c,v,r,t) } )$rsc_i(i)]
         = sum{(tt)$[(yeart(t) >= yeart(tt))], prescribedrsc(i,v,r,tt) }
-        + m_capacity_exog(i,v,r,t)
+        + sum{c, m_capacity_exog(i,c,v,r,t) }
 ;
 
 m_required_prescriptions_energy(i,v,r,t)$tmodel_new(t)
@@ -1946,11 +1948,11 @@ tc_phaseout_mult_t(i,t)$tmodel_new(t) = 1 ;
 valcap(i,v,r,t) = no ;
 
 *existing plants are enabled if not in ban(i)
-valcap(i,v,r,t)$[m_capacity_exog(i,v,r,t)$(not ban(i))$tmodel_new(t)] = yes ;
+valcap(i,v,r,t)$[sum{c, m_capacity_exog(i,c,v,r,t) }$(not ban(i))$tmodel_new(t)] = yes ;
 
 * if a plant is still available by upgrade year
 * and it is able to be upgraded - keep that plant in the valcap set
-valcap(i,v,r,t)$[sum{tt$[tt.val = Sw_UpgradeYear], m_capacity_exog(i,v,r,tt) }
+valcap(i,v,r,t)$[sum{(c,tt)$[tt.val = Sw_UpgradeYear], m_capacity_exog(i,c,v,r,tt) }
                 $(Sw_Upgrades = 1)$(t.val >= Sw_UpgradeYear)
                 $(not ban(i))
                 $sum{ii, upgrade_from(ii,i) }$tmodel_new(t)] = yes ;
@@ -2078,21 +2080,21 @@ valcap(i,v,r,t)$[upgrade(i)$(not Sw_Upgrades)] = no ;
 valcap(i,v,r,t)$[forced_retire(i,r,t)] = no ;
 
 * for any technologies that are forced to retire and cannot upgrade, remove m_capacity_exog
-m_capacity_exog(i,v,r,t)$[forced_retire(i,r,t)
+m_capacity_exog(i,c,v,r,t)$[forced_retire(i,r,t)
                          $(not sum{ii$(not forced_retire(ii,r,t)), upgrade_from(ii,i) })] = 0 ;
 
 * for any technologies that are forced to retire, can upgrade, and are not unabated coal, remove m_capacity_exog
-m_capacity_exog(i,v,r,t)$[forced_retire(i,r,t)$(not coal_noccs(i))
+m_capacity_exog(i,c,v,r,t)$[forced_retire(i,r,t)$(not coal_noccs(i))
                          $(sum{ii$(not forced_retire(ii,r,t)), upgrade_from(ii,i) })] = 0 ;
 
 * if Clean Air Act requirements are enabled, coal technologies that can be upgraded are allowed to stay in m_capacity_exog
 * if Clean Air Act requirements are not enabled, coal technologies that can be upgraded are excluded from m_capacity_exog
-m_capacity_exog(i,v,r,t)$[forced_retire(i,r,t)$(not Sw_Clean_Air_Act)$coal_noccs(i)
+m_capacity_exog(i,c,v,r,t)$[forced_retire(i,r,t)$(not Sw_Clean_Air_Act)$coal_noccs(i)
                          $(sum{ii$(not forced_retire(ii,r,t)) ,upgrade_from(ii,i) })] = 0 ;
 
 * If, in the last year in which coal must either retire or upgrade, coal is upgraded, we can continue to 
 * use that m_capacity_exog beyond caa_coal_retire_year. But unabated coal plants must not have capacity after caa_coal_retire_year.
-m_capacity_exog(i,v,r,t)$[forced_retire(i,r,t)$coal_noccs(i)
+m_capacity_exog(i,c,v,r,t)$[forced_retire(i,r,t)$coal_noccs(i)
                          $(t.val > caa_coal_retire_year)
                          $(sum{ii$(not forced_retire(ii,r,t)), upgrade_from(ii,i) }) ] = 0 ;
 
@@ -5360,7 +5362,7 @@ cost_co2_spurline_cap(r,cs,t) =  %GSw_CO2_CostAdj% * cost_co2_spurline_cap(r,cs,
 
 * Parameter tracking for sequential solve
 parameter
-    m_capacity_exog0(i,v,r,t) "--MW-- original value of m_capacity_exog used to make sure upgraded capacity isnt forced into retirement"
+    m_capacity_exog0(i,c,v,r,t) "--MW-- original value of m_capacity_exog used to make sure upgraded capacity isnt forced into retirement"
     z_rep(t)      "--$-- objective function value by year"
     z_rep_inv(t)  "--$-- investment component of objective function by year"
     z_rep_op(t)   "--$-- operation component of objective function by year"
@@ -5573,7 +5575,7 @@ mean_forced_outage_rate(i,r,ccseason,t) = 0 ;
 cost_vom(i,v,r,t)$[not valgen(i,v,r,t)] = 0 ;
 cost_fom(i,v,r,t)$[not valcap(i,v,r,t)] = 0 ;
 heat_rate(i,v,r,t)$[not valgen(i,v,r,t)] = 0 ;
-m_capacity_exog(i,v,r,t)$[not valcap(i,v,r,t)] = 0 ;
+m_capacity_exog(i,c,v,r,t)$[not valcap(i,v,r,t)] = 0 ;
 emit_rate(etype,e,i,v,r,t)$[not valgen(i,v,r,t)] = 0 ;
 
 *============================================================

--- a/reeds/core/setup/b_inputs.gms
+++ b/reeds/core/setup/b_inputs.gms
@@ -1170,7 +1170,7 @@ $offempty
 
 *Created using reeds/input_processing/writecapdat.py
 $onempty
-parameter prescribedrsc(i,v,r,allt) "--MW-- prescribed capacity data for resource supply curve (RSC) technologies"
+parameter prescribedrsc(i,c,v,r,allt) "--MW-- prescribed capacity data for resource supply curve (RSC) technologies"
 /
 $offlisting
 $ondelim
@@ -1754,22 +1754,22 @@ m_rscfeas(r,i,c,rscbin)$[i_c(i,c)$csp(i)$(not ban(i))$sum{ii$[(not ban(ii))$tg_r
 * Hybrid PV+battery
 m_rscfeas(r,i,c,rscbin)$[i_c(i,c)$pvb(i)$(not ban(i))$sum{ii$[(not ban(ii))$tg_rsc_upvagg(ii,i)], m_rscfeas(r,ii,c,rscbin) }] = yes ;
 
-parameter m_required_prescriptions(i,v,r,t)        "--MW-- required power prescriptions by year (cumulative)" ;
+parameter m_required_prescriptions(i,c,v,r,t)      "--MW-- required power prescriptions by year (cumulative)" ;
 
 parameter m_required_prescriptions_energy(i,v,r,t) "--MWh-- required energy prescriptions by year (cumulative)" ;
 
 *following does not include wind
 *conditional here is due to no prescribed retirements for RSC tech
 *distpv is an rsc tech but is handled different via binned_capacity as explained above
-m_required_prescriptions(i,v,r,t)$tmodel_new(t)
+m_required_prescriptions(i,c,v,r,t)$[tmodel_new(t)$i_c(i,c)]
           = sum{tt$[yeart(t)>=yeart(tt)], prescribednonrsc(i,v,r,tt) } ;
 
 
-m_required_prescriptions(i,v,r,t)$[tmodel_new(t)
-                                   $(sum{tt$[yeart(t)>=yeart(tt)], prescribedrsc(i,v,r,tt) }
-                                     or sum{c, m_capacity_exog(i,c,v,r,t) } )$rsc_i(i)]
-        = sum{(tt)$[(yeart(t) >= yeart(tt))], prescribedrsc(i,v,r,tt) }
-        + sum{c, m_capacity_exog(i,c,v,r,t) }
+m_required_prescriptions(i,c,v,r,t)$[tmodel_new(t)$i_c(i,c)
+                                   $(sum{tt$[yeart(t)>=yeart(tt)], prescribedrsc(i,c,v,r,tt) }
+                                     or m_capacity_exog(i,c,v,r,t) )$rsc_i(i)]
+        = sum{(tt)$[(yeart(t) >= yeart(tt))], prescribedrsc(i,c,v,r,tt) }
+        + m_capacity_exog(i,c,v,r,t)
 ;
 
 m_required_prescriptions_energy(i,v,r,t)$tmodel_new(t)
@@ -1808,7 +1808,8 @@ prescribed_build(i,v,r,t)$tmodel_new(t)
 * previous modeled year and the current year
                                           $(yeart(tt)>sum{ttt$tprev(t,ttt), yeart(ttt) }))
                                           ],
-                                        prescribednonrsc(i,v,r,tt) + prescribedrsc(i,v,r,tt)
+                                        prescribednonrsc(i,v,r,tt)
+                                        + sum{c, prescribedrsc(i,c,v,r,tt) }
                                       } ;
 
 parameter prescribed_build_energy(i,v,r,t) "--MWh-- prescribed energy capacity that comes online in a given year" ;
@@ -1978,13 +1979,13 @@ valcap(i,newv,r,t)$[rsc_i(i)$tmodel_new(t)$(not ban(i))$(not bannew(i))
 *enable capacity if there is a required prescription in that region
 *first for non-rsc techs
 valcap(i,newv,r,t)$[(not rsc_i(i))
-                    $m_required_prescriptions(i,newv,r,t)
-                    $sum{tt$[m_required_prescriptions(i,newv,r,tt) 
+                    $sum{c, m_required_prescriptions(i,c,newv,r,t) }
+                    $sum{(c,tt)$[m_required_prescriptions(i,c,newv,r,tt) 
                           $(yeart(tt)<=yeart(t))], ivt(i,newv,tt) }$(not ban(i))] = yes ;
 *then for rsc techs
 valcap(i,newv,r,t)$[rsc_i(i)
-                    $m_required_prescriptions(i,newv,r,t)
-                    $sum{tt$[m_required_prescriptions(i,newv,r,tt) 
+                    $sum{c, m_required_prescriptions(i,c,newv,r,t) }
+                    $sum{(c,tt)$[m_required_prescriptions(i,c,newv,r,tt) 
                       $(yeart(tt)<=yeart(t))], ivt(i,newv,tt) }$(not ban(i))
                     $sum{(c,rscbin), m_rscfeas(r,i,c,rscbin) }] = yes ;
 
@@ -2005,7 +2006,7 @@ valcap(i,newv,r,t)
 *therefore remove the consideration of valcap if...
 valcap(i,newv,r,t)$[
 *if there are no required prescriptions
-                   (not m_required_prescriptions(i,newv,r,t))
+                   (not sum{c, m_required_prescriptions(i,c,newv,r,t) })
 *if the year is before the first year the technology is allowed
                    $(yeart(t)<firstyear(i))
 *if there is not a mandate for that technology in the region
@@ -2015,8 +2016,8 @@ valcap(i,newv,r,t)$[
 *remove vintages that cannot be built because they only occur before firstyear
 valcap(i,newv,r,t)$[
 *if there are no required prescriptions before the last year of that vintage
-                   (not sum{tt$[(yeart(tt)<=lastyear_v(i,newv))],
-                      m_required_prescriptions(i,newv,r,tt) } )
+                   (not sum{(c,tt)$[(yeart(tt)<=lastyear_v(i,newv))],
+                      m_required_prescriptions(i,c,newv,r,tt) } )
 *if the vintage is not allowed before the firstyear
                    $(lastyear_v(i,newv)<firstyear(i))
 *if there is not a mandate for that technology in the region
@@ -2032,7 +2033,7 @@ valcap(i,newv,r,t)$[(not sameas(i,'gas-ct'))$(yeart(t)<firstyear(i))
 
 *enable prescribed builds of technologies that are earlier listed in bannew when Sw_WaterMain is ON
 valcap(i,newv,r,t)$[Sw_WaterMain$sum{ctt$bannew_ctt(ctt),i_ctt(i,ctt) }$tmodel_new(t)
-                  $sum{tt$[yeart(tt)<=yeart(t)], m_required_prescriptions(i,newv,r,tt) }
+                  $sum{(c,tt)$[yeart(tt)<=yeart(t)], m_required_prescriptions(i,c,newv,r,tt) }
                   $sum{tt$(yeart(tt)<=yeart(t)), ivt(i,newv,tt) }] = yes ;
 
 
@@ -5125,7 +5126,7 @@ if (Sw_ReducedResource = 1,
 *Calculate the fraction of prescribed builds to the available resource
 * 2021-05-05 the prescriptions are being applied across all years until we decide a better way to do this
   prescrip_rsc_frac(i,r)$[sum{(c,rscbin), m_rsc_dat(r,i,c,rscbin,"cap") } > 0] =
-      smax((tt),sum{newv,m_required_prescriptions(i,newv,r,tt)}) / sum{(c,rscbin), m_rsc_dat(r,i,c,rscbin,"cap") } ;
+      smax((tt),sum{(c,newv),m_required_prescriptions(i,c,newv,r,tt)}) / sum{(c,rscbin), m_rsc_dat(r,i,c,rscbin,"cap") } ;
 *Set the default resource reduction fraction
   rsc_reduct_frac(i,r) = reduced_resource_frac ;
 *If the resource reduction fraction will reduce the resource to the point that prescribed builds will be infeasible,

--- a/reeds/core/setup/b_inputs.gms
+++ b/reeds/core/setup/b_inputs.gms
@@ -1799,17 +1799,17 @@ degrade(i,t,tt)$[(yeart(tt)>=yeart(t))$(not ban(i))] = (1-degrade_annual(i))**(y
 
 set prescription_check(i,v,r,t) "check to see if prescriptive capacity comes online in a given year" ;
 
-parameter prescribed_build(i,v,r,t) "--MW-- prescribed capacity that comes online in a given year" ;
+parameter prescribed_build(i,c,v,r,t) "--MW-- prescribed capacity that comes online in a given year" ;
 * need to fill in for unmodeled, gap years via tprev but
 * tprev is not defined with tprev(t,tfirst)
-prescribed_build(i,v,r,t)$tmodel_new(t)
+prescribed_build(i,c,v,r,t)$[tmodel_new(t)$i_c(i,c)]
                                   = sum{tt$[(yeart(tt)<=yeart(t)
 * this condition populates values of tt which exist between the
 * previous modeled year and the current year
                                           $(yeart(tt)>sum{ttt$tprev(t,ttt), yeart(ttt) }))
                                           ],
                                         prescribednonrsc(i,v,r,tt)
-                                        + sum{c, prescribedrsc(i,c,v,r,tt) }
+                                        + prescribedrsc(i,c,v,r,tt)
                                       } ;
 
 parameter prescribed_build_energy(i,v,r,t) "--MWh-- prescribed energy capacity that comes online in a given year" ;
@@ -1832,13 +1832,13 @@ prescribed_retirements_energy(i,v,r,t,tt)$[tmodel_new(tt)$tmodel_new(t)]
                                   = prescribedretirements_energy(v,r,i,t,tt,"prescribed") ;
 
 
-prescription_check(i,newv,r,t)$[prescribed_build(i,newv,r,t)
+prescription_check(i,newv,r,t)$[sum{c, prescribed_build(i,c,newv,r,t) }
                                  $ivt(i,newv,t)$tmodel_new(t)$(not ban(i))] = yes ;
 
 *Extend feasibility for prescribed rsc capacity where there is no supply curve data.
 *Resource will be manualy added to supply curve in bin1 in these cases.
 *Only enable for bin1 if there is no resource in any bins to keep parameter size down.
-m_rscfeas(r,i,c,"bin1")$[i_c(i,c)$sum{(newv,t)$[tmodel_new(t)], prescribed_build(i,newv,r,t) }$rsc_i(i)$(not bannew(i))$(sum{rscbin, rsc_dat(i,c,r,"cap",rscbin) }=0)] = yes ;
+m_rscfeas(r,i,c,"bin1")$[i_c(i,c)$sum{(newv,t)$[tmodel_new(t)], prescribed_build(i,c,newv,r,t) }$rsc_i(i)$(not bannew(i))$(sum{rscbin, rsc_dat(i,c,r,"cap",rscbin) }=0)] = yes ;
 
 *==========================================================
 *--- Interconnection queues (Capacity deployment limit) ---
@@ -1995,7 +1995,7 @@ valcap(i,newv,r,t)$bannew(i) = no ;
 valcap(i,newv,r,t)
        $[bannew(i)
        $(not ban(i))
-       $sum{tt$ivt(i,newv,tt), prescribed_build(i,newv,r,tt)}]
+       $sum{(c,tt)$ivt(i,newv,tt), prescribed_build(i,c,newv,r,tt)}]
        = yes ;
 
 *NEW capacity only valid in historical years if and only if it has required prescriptions
@@ -2133,17 +2133,17 @@ valinv(i,v,r,t) = no ;
 valinv(i,v,r,t)$[valcap(i,v,r,t)$ivt(i,v,t)] = yes ;
 
 * Do not allow investments in regions where that technology is banned, expect for prescribed builds
-valinv(i,v,r,t)$[tech_banned(i,r)$(not prescribed_build(i,v,r,t))] = no ;
+valinv(i,v,r,t)$[tech_banned(i,r)$(not sum{c, prescribed_build(i,c,v,r,t) })] = no ;
 
 *remove non-prescribed numeraire technologies that remain in valcap
-valinv(i,newv,r,t)$[i_numeraire(i)$Sw_WaterMain$(not prescribed_build(i,newv,r,t))] = no ;
+valinv(i,newv,r,t)$[i_numeraire(i)$Sw_WaterMain$(not sum{c, prescribed_build(i,c,newv,r,t) })] = no ;
 
 *upgrades are not allowed for the INV variable as they are the sum of UPGRADES
 valinv(i,v,r,t)$upgrade(i) = no ;
 
 valinv(i,v,r,t)$[(yeart(t)<firstyear(i))
 * Allow investments before firstyear(i) in technologies with prescribed capacity
-                 $(not prescribed_build(i,v,r,t))
+                 $(not sum{c, prescribed_build(i,c,v,r,t) })
 * Allow investments before firstyear(i) in mandated technologies
                  $(not [sum{st$r_st(r,st), batterymandate(st,t) }  and battery(i)])
                  $(not [sum{st$r_st(r,st), offshore_cap_req(st,t)} and ofswind(i)])
@@ -2213,7 +2213,7 @@ inv_cond(i,newv,r,t,tt)$[(not ban(i))
                       ] = yes ;
 
 inv_cond(i,newv,r,t,tt)$[Sw_WaterMain$sum{ctt$bannew_ctt(ctt),i_ctt(i,ctt) }$tmodel_new(t)$tmodel_new(tt)
-                      $prescribed_build(i,newv,r,tt)
+                      $sum{c, prescribed_build(i,c,newv,r,tt) }
                       $(yeart(tt) <= yeart(t))
                       $valinv(i,newv,r,tt)
                       $(ord(t)-ord(tt) < maxage(i))
@@ -5186,7 +5186,7 @@ available_supply(i,r) = 0 ;
 cap_existing(i,r)$exog_rsc(i) = sum{(c,v,t,rscbin)$[tfirst(t)], capacity_exog_rsc(i,c,v,r,rscbin,t) } ;
 
 *Get prescribed capacity
-cap_prescribed(i,r,t)$[rsc_i(i)$tmodel_new(t)] = sum{v, prescribed_build(i,v,r,t) } ;
+cap_prescribed(i,r,t)$[rsc_i(i)$tmodel_new(t)] = sum{(c,v), prescribed_build(i,c,v,r,t) } ;
 cap_prescribed_ir(i,r)$rsc_i(i) = sum{t$tmodel_new(t), cap_prescribed(i,r,t) } ;
 
 *Get total available supply for all i .
@@ -5271,7 +5271,7 @@ m_rsc_dat(r,i,c,rscbin,sc_cat)$[i_c(i,c)$sum{ii$rsc_agg(ii,i), m_rsc_dat(r,ii,c,
 set force_prescribe(i,v,r,t) "conditional to indicate whether the force prescription equation should be active for technology i and vintage v in year t" ;
 
 force_prescribe(i,v,r,t)$[(yeart(t) < firstyear(i))$newv(v)] = yes ;
-force_prescribe(i,v,r,t)$[ prescribed_build(i,v,r,t)] = yes ;
+force_prescribe(i,v,r,t)$[ sum{c, prescribed_build(i,c,v,r,t) }] = yes ;
 
 *=========================================
 * Decoupled Capacity/Energy Upgrades for hydropower

--- a/reeds/core/setup/c_model.gms
+++ b/reeds/core/setup/c_model.gms
@@ -954,7 +954,7 @@ eq_forceprescription_power(i,newv,r,t)
 
 *must equal the cumulative prescribed amount
 
-        prescribed_build(i,newv,r,t)
+        sum{c, prescribed_build(i,c,newv,r,t) }
 
 * plus any extra power buildouts (no penalty here - used as free slack)
 * only on or after the first year the techs are available

--- a/reeds/core/setup/c_model.gms
+++ b/reeds/core/setup/c_model.gms
@@ -585,7 +585,7 @@ $offtext
 eq_cap_init_noret(i,v,r,t)$[valcap(i,v,r,t)$tmodel(t)$initv(v)$(not upgrade(i))
                            $(not retiretech(i,v,r,t))$(not Sw_PCM)]..
 
-    m_capacity_exog(i,v,r,t)
+    sum{c, m_capacity_exog(i,c,v,r,t) }
 
 * Account for capacity upsizing within init vintages
     + sum{(tt,rscbin)$[(tmodel(tt) or tfix(tt))$allow_cap_up(i,v,r,rscbin,tt)],
@@ -615,7 +615,7 @@ eq_cap_init_noret(i,v,r,t)$[valcap(i,v,r,t)$tmodel(t)$initv(v)$(not upgrade(i))
 eq_cap_init_retub(i,v,r,t)$[valcap(i,v,r,t)$tmodel(t)$initv(v)$(not upgrade(i))
                            $retiretech(i,v,r,t)$(not Sw_PCM)]..
 
-    m_capacity_exog(i,v,r,t)
+    sum{c, m_capacity_exog(i,c,v,r,t) }
 
 * Account for capacity upsizing within init vintages
     + sum{(tt,rscbin)$[(tmodel(tt) or tfix(tt))$allow_cap_up(i,v,r,rscbin,tt)],
@@ -2814,7 +2814,7 @@ eq_RPS_OFSWind(st,t)$[tmodel(t)$stfeas(st)$offshore_cap_req(st,t)$Sw_StateRPS
                       $(yeart(t)>=firstyear_RPS)$(not Sw_PCM)]..
 
 * existing capacity of wind
-    sum{(i,v,r)$[r_st(r,st)$ofswind(i)], m_capacity_exog(i,v,r,t) }
+    sum{(i,c,v,r)$[r_st(r,st)$ofswind(i)], m_capacity_exog(i,c,v,r,t) }
 
 * investments over time
     + sum{(i,v,r,tt)$[r_st(r,st)$ofswind(i)$inv_cond(i,v,r,t,tt)$(tmodel(tt) or tfix(tt))],

--- a/reeds/core/setup/e_solveprep.gms
+++ b/reeds/core/setup/e_solveprep.gms
@@ -85,7 +85,7 @@ capture_rate(e,i,v,r,t)$valgen(i,v,r,t) = round(capture_rate(e,i,v,r,t),6) ;
 fuel_price(i,r,t)$fuel_price(i,r,t) = round(fuel_price(i,r,t),2) ;
 gasmultterm(cendiv,t)$gasmultterm(cendiv,t) = round(gasmultterm(cendiv,t),3) ;
 heat_rate(i,v,r,t)$heat_rate(i,v,r,t) = round(heat_rate(i,v,r,t),2) ;
-m_capacity_exog(i,v,r,t)$[valcap(i,v,r,t)$(not sameas(i,"smr"))] = round(m_capacity_exog(i,v,r,t),3) ;
+m_capacity_exog(i,c,v,r,t)$[valcap(i,v,r,t)$(not sameas(i,"smr"))] = round(m_capacity_exog(i,c,v,r,t),3) ;
 m_capacity_exog_energy(i,v,r,t)$[valcap(i,v,r,t)] = round(m_capacity_exog_energy(i,v,r,t),3) ;
 m_rsc_dat(r,i,c,rscbin,"cap")$m_rsc_dat(r,i,c,rscbin,"cap") = round(m_rsc_dat(r,i,c,rscbin,"cap"),3) ;
 m_rsc_dat(r,i,c,rscbin,"cost")$m_rsc_dat(r,i,c,rscbin,"cost") = round(m_rsc_dat(r,i,c,rscbin,"cost"),2) ;
@@ -116,7 +116,7 @@ winter_cap_frac_delta(i,v,r)$winter_cap_frac_delta(i,v,r) = round(winter_cap_fra
 $ifthen.seq %timetype%=="seq"
 
 * -- upgrade capacity tracking --
-m_capacity_exog0(i,v,r,t) = m_capacity_exog(i,v,r,t) ;
+m_capacity_exog0(i,c,v,r,t) = m_capacity_exog(i,c,v,r,t) ;
 
 * remove cc_int as it is only used in the intertemporal setting
 cc_int(i,v,r,ccseason,t) = 0 ;

--- a/reeds/core/solve/2_temporal_params.gms
+++ b/reeds/core/solve/2_temporal_params.gms
@@ -526,7 +526,7 @@ m_cf(i,c,v,r,h,t)$[(m_cf(i,c,v,r,h,t)<0.01)$valcap(i,v,r,t)] = 0 ;
 m_cf(i,c,v,r,h,t)$[cf_tech(i)$valcap(i,v,r,t)$m_cf(i,c,v,r,h,t)] = round(m_cf(i,c,v,r,h,t),3) ;
 
 * Remove capacity when there is no corresponding capacity factor
-m_capacity_exog(i,v,r,t)$[initv(v)$cf_tech(i)$(not sum{(h,c)$i_c(i,c), m_cf(i,c,v,r,h,t) })] = 0 ;
+m_capacity_exog(i,c,v,r,t)$[initv(v)$cf_tech(i)$(not sum{h, m_cf(i,c,v,r,h,t) })] = 0 ;
 
 * Average CF by season
 m_cf_szn(i,v,r,allszn,t) = 0 ;
@@ -562,7 +562,7 @@ dayhours(h)$[sum{(i,c,v,r,t)$[pv(i)$valgen(i,v,r,t)$i_c(i,c)], m_cf(i,c,v,r,h,t)
 if(%cur_year% = sum{t$tfirst(t), yeart(t) },
     wat_supply_init(wst,r) = sum{(i,v,h,t)$[h_rep(h)$valcap(i,v,r,t)$initv(v)$i_wst(i,wst)$tfirst(t)],
                                 hours(h)
-                                * (sum{w$i_w(i,w), m_capacity_exog(i,v,r,t) * water_rate(i,w)}) 
+                                * (sum{(c,w)$i_w(i,w), m_capacity_exog(i,c,v,r,t) * water_rate(i,w)}) 
                                 * (1 + sum{szn, h_szn(h,szn) * seas_cap_frac_delta(i,v,r,szn,t)})
                                 } / 1E6 ;
 

--- a/reeds/core/solve/3_solve_allyears.gms
+++ b/reeds/core/solve/3_solve_allyears.gms
@@ -159,7 +159,7 @@ execute_unload 'gdxfiles%ds%%case%_load.gdx' ;
 cap_iter(i,v,r,t,"%niter%")$valcap(i,v,r,t) = CAP.l(i,v,r,t) ;
 cap_energy_iter(i,v,r,t,"%niter%")$valcap(i,v,r,t) = CAP_ENERGY.l(i,v,r,t) ;
 gen_iter(i,v,r,t,"%niter%")$valcap(i,v,r,t) = sum{h, GEN.l(i,v,r,h,t) * hours(h) } ;
-gen_iter(i,v,r,t,"%niter%")$[vre(i)$valcap(i,v,r,t)] = sum{(h,c)$i_c(i,c), m_cf(i,c,v,r,h,t) * CAP.l(i,v,r,t) * hours(h) } ;
+gen_iter(i,v,r,t,"%niter%")$[vre(i)$valcap(i,v,r,t)] = sum{(h,c)$valcap_class(i,c,v,r,t), m_cf(i,c,v,r,h,t) * CAP_CLASS.l(i,c,v,r,t) * hours(h) } ;
 cap_firm_iter(i,v,r,szn,t,"%niter%")$cc_int(i,v,r,szn,t) = cc_int(i,v,r,szn,t) * CAP.l(i,v,r,t) ;
 cap_firm_iter(i,v,r,szn,t,"%niter%")$storage(i) = sum{sdbin, CAP_SDBIN.l(i,v,r,szn,sdbin,t) * cc_storage(i,sdbin) } ;
 cap_energy_firm_iter(i,v,r,szn,t,"%niter%")$storage(i) = sum{sdbin, CAP_SDBIN_ENERGY.l(i,v,r,szn,sdbin,t) } ;

--- a/reeds/core/solve/3_solve_oneyear.gms
+++ b/reeds/core/solve/3_solve_oneyear.gms
@@ -78,11 +78,11 @@ loop(i$rsc_i(i),
 * to avoid forcing recently upgraded capacity into retirement
 if(Sw_Upgrades = 1,
 
-    m_capacity_exog(i,v,r,t)$[valcap(i,v,r,t)$sameas(t,"%cur_year%")
+    m_capacity_exog(i,c,v,r,t)$[valcap(i,v,r,t)$sameas(t,"%cur_year%")
                          $(sum{(ii,tt)$[(tt.val <= t.val)$(t.val - tt.val <= Sw_UpgradeLifespan)
                                        $valcap(ii,v,r,tt)$upgrade_from(ii,i)], UPGRADES.l(ii,v,r,tt) } ) ] =
 * [maximum of] initial capacity recorded in e_solveprep
-                    max( m_capacity_exog0(i,v,r,t),
+                    max( m_capacity_exog0(i,c,v,r,t),
 * -or- capacity of upgrades that have occurred from this i v r t combination
                     sum{(ii,tt)$[(tt.val <= t.val)$(t.val - tt.val <= Sw_UpgradeLifespan)
                                  $valcap(ii,v,r,tt)$upgrade_from(ii,i)],
@@ -194,7 +194,7 @@ $include reeds%ds%core%ds%solve%ds%2_financials.gms
 
 $ifthene %cur_year%==%startyear%
 *initialize CAP.l for 2010 because it has not been defined yet
-CAP.l(i,v,r,"%startyear%")$[m_capacity_exog(i,v,r,"%startyear%")] = m_capacity_exog(i,v,r,"%startyear%") ;
+CAP.l(i,v,r,"%startyear%")$[sum{c, m_capacity_exog(i,c,v,r,"%startyear%") }] = sum{c, m_capacity_exog(i,c,v,r,"%startyear%") } ;
 $endif
 
 $ifthene %cur_year%==%startyear%

--- a/reeds/core/solve/3_solve_oneyear.gms
+++ b/reeds/core/solve/3_solve_oneyear.gms
@@ -78,7 +78,7 @@ loop(i$rsc_i(i),
 * to avoid forcing recently upgraded capacity into retirement
 if(Sw_Upgrades = 1,
 
-    m_capacity_exog(i,c,v,r,t)$[valcap(i,v,r,t)$sameas(t,"%cur_year%")
+    m_capacity_exog(i,c,v,r,t)$[i_c(i,c)$valcap(i,v,r,t)$sameas(t,"%cur_year%")
                          $(sum{(ii,tt)$[(tt.val <= t.val)$(t.val - tt.val <= Sw_UpgradeLifespan)
                                        $valcap(ii,v,r,tt)$upgrade_from(ii,i)], UPGRADES.l(ii,v,r,tt) } ) ] =
 * [maximum of] initial capacity recorded in e_solveprep

--- a/reeds/core/solve/6_data_dump.gms
+++ b/reeds/core/solve/6_data_dump.gms
@@ -142,7 +142,7 @@ ret_ivrt(i,c,v,r,t)$([abs(ret_ivrt(i,c,v,r,t) < 1e-6)]$valcap(i,v,r,t)) = 0 ;
 
 ret(i,v,r)$valcap_ivr(i,v,r) = sum{(c,t)$i_c(i,c), ret_ivrt(i,c,v,r,t) } ;
 
-cap_exog_filt(i,v,r)$([not canada(i)]$valcap_ivr(i,v,r)) = sum{t$tnext(t), m_capacity_exog(i,v,r,t) } ;
+cap_exog_filt(i,v,r)$([not canada(i)]$valcap_ivr(i,v,r)) = sum{(c,t)$tnext(t), m_capacity_exog(i,c,v,r,t) } ;
 
 gen_h_stress_filt(i,r,allh,t)$[tcur(t)$valgen_irt(i,r,t)$h_stress_t(allh,t)] =
   sum{v$valgen(i,v,r,t), GEN.l(i,v,r,allh,t)}
@@ -205,7 +205,7 @@ avail_filt(i,v,r,szn)$[cap_exist_iv(i,v)$(not vre(i))] =
 
 can_exports_h_filt(r,h) = sum{t$tcur(t), can_exports_h(r,h,t)} ;
 
-can_imports_cap(i,v,r)$canada(i) = sum{t$tcur(t), m_capacity_exog(i,v,r,t) } ;
+can_imports_cap(i,v,r)$canada(i) = sum{(c,t)$tcur(t), m_capacity_exog(i,c,v,r,t) } ;
 
 can_imports_szn_filt(r,szn) = sum{t$tcur(t), can_imports_szn(r,szn,t)} ;
 

--- a/reeds/core/terminus/report.gms
+++ b/reeds/core/terminus/report.gms
@@ -782,7 +782,10 @@ opres_trade(ortype,r,rr,t)$[opres_routes(r,rr,t)$tmodel_new(t)] =
 *=========================
 
 gen_new_uncurt(i,r,h,t)$[(vre(i) or storage_hybrid(i)$(not csp(i)))$valcap_irt(i,r,t)] =
-      sum{(v,c)$[i_c(i,c)$valinv(i,v,r,t)], (INV.l(i,v,r,t) + INV_REFURB.l(i,c,v,r,t)) * m_cf(i,c,v,r,h,t) * hours(h) }
+      sum{(v,c)$[i_c(i,c)$valinv(i,v,r,t)],
+          (INV.l(i,v,r,t)$(not rsc_i(i))
+           + sum{rscbin$m_rscfeas(r,i,c,rscbin), INV_RSC.l(i,c,v,r,rscbin,t) }$rsc_i(i)
+           + INV_REFURB.l(i,c,v,r,t)) * m_cf(i,c,v,r,h,t) * hours(h) }
 ;
 
 * curtailment = (availability - generation - operating reserves)

--- a/reeds/core/terminus/report.gms
+++ b/reeds/core/terminus/report.gms
@@ -848,9 +848,7 @@ cap_out(i,c,r,t)$[upv(i)$i_c(i,c)$cap_cspns(c,r,t)$tmodel_new(t)] =
 cap_nat(i,t)$tmodel_new(t) = sum{(c,r)$i_c(i,c), cap_out(i,c,r,t) } ;
 
 * Exogenous capacity (used by reeds_to_rev)
-cap_exog(i,c,v,r,t)$[i_c(i,c)$tmodel_new(t)] = m_capacity_exog(i,v,r,t) ;
-cap_exog(i,c,v,r,t)$[i_c(i,c)$tmodel_new(t)$exog_rsc(i)] =
-    sum{rscbin, capacity_exog_rsc(i,c,v,r,rscbin,t) } ;
+cap_exog(i,c,v,r,t)$[i_c(i,c)$tmodel_new(t)] = m_capacity_exog(i,c,v,r,t) ;
 
 *=========================
 * NEW CAPACITY

--- a/reeds/input_processing/hourly_plots.py
+++ b/reeds/input_processing/hourly_plots.py
@@ -286,7 +286,8 @@ def plot_maps(sw, inputs_case, reeds_path, figpath, periodtype='rep', crs='EPSG:
         dfsc['longitude'] = dfsc.sc_point_gid.map(sitemap.longitude)
         dfsc = plots.df2gdf(dfsc, crs=crs)
         dfsc['resource'] = dfsc.i + '|' + dfsc.r
-        dfsc['cf_actual'] = dfsc.resource.map(recf)
+        dfsc['resource_recf'] = dfsc.i + '|' + dfsc['class'].astype(str) + '|' + dfsc.r
+        dfsc['cf_actual'] = dfsc.resource_recf.map(recf)
 
         ### Get the annual average CF of the hourly-processed data
         cf_hourly = dfcf.loc[dfcf.i.str.startswith(tech)].pivot(

--- a/reeds/input_processing/hourly_repperiods.py
+++ b/reeds/input_processing/hourly_repperiods.py
@@ -281,7 +281,7 @@ def main(
     ### Downselect to modeled regions
     sc = sc.loc[sc.region.isin(val_r_all)].copy()
     sc['i'] = sc.tech+'_'+sc['class'].astype(str)
-    sc['resource'] = sc.i + '|' + sc.region
+    sc['resource'] = sc.i + '|' + sc['class'].astype(str) + '|' + sc.region
     sc['aggreg'] = sc.region.map(rmap)
 
     #%%### Load RE CF data, then take available-capacity-weighted average by (tech,region)

--- a/reeds/input_processing/hourly_writetimeseries.py
+++ b/reeds/input_processing/hourly_writetimeseries.py
@@ -606,7 +606,7 @@ def main(sw, reeds_path, inputs_case, periodtype='rep', make_plots=1, logging=Tr
 
     cf_out = cf_rep.rename_axis("h").copy()
     i = cf_rep.columns.map(lambda x: x.split("|")[0])
-    r = cf_rep.columns.map(lambda x: x.split("|")[1])
+    r = cf_rep.columns.map(lambda x: x.split("|")[-1])
     cf_out.columns = pd.MultiIndex.from_arrays([i, r], names=["i", "r"])
     cf_out = (
         cf_out.stack(["i", "r"])

--- a/reeds/input_processing/recf.py
+++ b/reeds/input_processing/recf.py
@@ -532,9 +532,7 @@ def main(reeds_path, inputs_case):
     #    -- Data Write-Out --    #
     ##############################
 
-    ### Key each profile by tech, class and region. Class is still part of the tech
-    ### name here, but the name alone will no longer identify a profile once tech is
-    ### is not part of the name.
+    ### Key each profile by tech, class and region
     rekey = dict(zip(
         resources['resource'],
         resources['i'] + '|' + resources['c'].astype(str) + '|' + resources['r'],

--- a/reeds/input_processing/recf.py
+++ b/reeds/input_processing/recf.py
@@ -532,6 +532,16 @@ def main(reeds_path, inputs_case):
     #    -- Data Write-Out --    #
     ##############################
 
+    ### Key each profile by tech, class and region. Class is still part of the tech
+    ### name here, but the name alone will no longer identify a profile once tech is
+    ### is not part of the name.
+    rekey = dict(zip(
+        resources['resource'],
+        resources['i'] + '|' + resources['c'].astype(str) + '|' + resources['r'],
+    ))
+    recf.columns = recf.columns.map(rekey)
+    resources['resource'] = resources['resource'].map(rekey)
+
     reeds.io.write_profile_to_h5(recf.astype(np.float16), 'recf.h5', inputs_case)
     resources.to_csv(os.path.join(inputs_case,'resources.csv'), index=False)
     ### Write the CSP solar field CF (no SM or storage) for hourly_writetimeseries.py

--- a/reeds/input_processing/writecapdat.py
+++ b/reeds/input_processing/writecapdat.py
@@ -267,8 +267,8 @@ COLNAMES = {
             ['t','i','v','r','coolingwatertech','ctt','wst','value']
         ),
         'prescribed_RSC': (
-            ['StartYear','tech','vin','r','summer_power_capacity_MW'],
-            ['t','i','v','r','value']
+            ['StartYear','tech','class','vin','r','summer_power_capacity_MW'],
+            ['t','i','c','v','r','value']
         ),
         'rsc': (
             ['tech','r','v','ctt','wst','summer_power_capacity_MW'],
@@ -710,7 +710,7 @@ def main(reeds_path, inputs_case):
             cap_pres[tech] =  pd.merge(cap_pres[tech], ivt_df_mask, how='left', left_on='StartYear', right_on='year')
             cap_pres[tech] = cap_pres[tech][COLNAMES['prescribed_RSC'][0]]
             cap_pres[tech].columns = COLNAMES['prescribed_RSC'][1]
-            cap_pres[tech] = cap_pres[tech].groupby(['i','v','r','t']).sum().reset_index()
+            cap_pres[tech] = cap_pres[tech].groupby(['i','c','v','r','t']).sum().reset_index()
     # Concat all RSC Existing Data to one dataframe:
     prescribed_rsc = pd.concat([cap_pres[tech] for tech in TECH["rsc_wsc"]
                                 if tech in cap_pres and not cap_pres[tech].empty],ignore_index=True)
@@ -968,7 +968,7 @@ def main(reeds_path, inputs_case):
 
     # Final Groupby step for capacity groupings not affected by GSw_WaterMain:
     caprsc = caprsc.groupby(['i','v','r']).value.sum().reset_index()
-    prescribed_rsc = prescribed_rsc.groupby(['i','v','r','t']).value.sum().reset_index()
+    prescribed_rsc = prescribed_rsc.groupby(['i','c','v','r','t']).value.sum().reset_index()
 
 
     #%%----------------------------------------------------------------------------
@@ -1033,7 +1033,7 @@ def main(reeds_path, inputs_case):
                 'prescribed_nonRSC' : prescribed_nonRSC[['i','v','r','t','value']],
                 'prescribed_nonRSC_energy' : prescribed_nonRSC_energy[['i','v','r','t','value']],
                 'caprsc' :caprsc[['i','v','r','value']],
-                'prescribed_rsc' : prescribed_rsc[['i','v','r','t','value']],
+                'prescribed_rsc' : prescribed_rsc[['i','c','v','r','t','value']],
                 'wind_rets' : wind_rets,
                 'h2_existing_smr_cap' : h2_existing_smr_cap[['r','t','value']],
                 'geo_retirements' : geo_retirements,

--- a/reeds/input_processing/writesupplycurves.py
+++ b/reeds/input_processing/writesupplycurves.py
@@ -146,9 +146,6 @@ def main(
         "egs": int(sw.numbins_egs_allkm),
     }
 
-    ### Resource class of each technology; techs with no class are assigned class '0'
-    i2c = reeds.techs.get_class_map(inputs_case)
-
     val_r_all = pd.read_csv(
         os.path.join(inputs_case,'val_r_all.csv'), header=None).squeeze(1).tolist()
     # Read in tech-subset-table.csv to determine number of csp configurations
@@ -231,6 +228,7 @@ def main(
             )
         )
 
+        cost_components["c"] = cost_components["*i"].astype(str)
         cost_components["*i"] = f"wind-{s}_" + cost_components[
             "*i"
         ].astype(str)
@@ -239,7 +237,7 @@ def main(
         ].astype(str)
         cost_components = pd.melt(
             cost_components,
-            id_vars=["*i", "r", "rscbin"],
+            id_vars=["*i", "c", "r", "rscbin"],
             var_name="sc_cat",
             value_name="value",
         )
@@ -329,11 +327,12 @@ def main(
             "capital_adder_per_mw": "cost_cap",
         }
     )
+    cost_components_upv["c"] = cost_components_upv["*i"].astype(str)
     cost_components_upv["*i"] = "upv_" + cost_components_upv["*i"].astype(str)
     cost_components_upv["rscbin"] = "bin" + cost_components_upv["rscbin"].astype(str)
     cost_components_upv = pd.melt(
         cost_components_upv,
-        id_vars=["*i", "r", "rscbin"],
+        id_vars=["*i", "c", "r", "rscbin"],
         var_name="sc_cat",
         value_name="value",
     )
@@ -682,8 +681,9 @@ def main(
     alloutcost["class"] = alloutcost["class"].map(lambda x: x.lstrip("class"))
 
     allout = pd.concat([outcapfin, alloutcost])
+    allout["c"] = allout["class"].astype(str)
     allout["tech"] = allout["tech"] + "_" + allout["class"].astype(str)
-    alloutm = pd.melt(allout, id_vars=["r", "tech", "var"])
+    alloutm = pd.melt(allout, id_vars=["r", "tech", "c", "var"])
     alloutm.rename(columns={"bin":"variable"}, inplace=True)
     alloutm = alloutm.loc[alloutm.variable != "class"].copy()
     allout_list = [alloutm]
@@ -721,7 +721,8 @@ def main(
     hyddat["class"] = hyddat["class"].map(lambda x: x.replace("hydclass", ""))
 
     hyddat.rename(columns={"variable": "r", "bin": "variable"}, inplace=True)
-    hyddat = hyddat[["tech", "r", "value", "var", "variable"]].fillna(0)
+    hyddat["c"] = "0"
+    hyddat = hyddat[["tech", "c", "r", "value", "var", "variable"]].fillna(0)
     allout_list.append(hyddat)
 
     #########################################
@@ -748,6 +749,7 @@ def main(
         psh_out = pd.concat([psh_cap, psh_cost]).fillna(0)
         psh_out["tech"] = "pumped-hydro"
         psh_out["variable"] = psh_out.variable.map(lambda x: x.replace("pshclass", "bin"))
+        psh_out["c"] = "0"
         psh_out = psh_out[hyddat.columns].copy()
         allout_list.append(psh_out)
 
@@ -855,7 +857,8 @@ def main(
         dr_shed_dat['class'] = dr_shed_dat['class'].map(lambda x: x.replace('dr_shed_',''))
 
         dr_shed_dat.rename(columns={'variable':'r','bin':'variable'}, inplace=True)
-        dr_shed_dat = dr_shed_dat[['tech','r','value','var','variable']].fillna(0)
+        dr_shed_dat['c'] = '0'
+        dr_shed_dat = dr_shed_dat[['tech','c','r','value','var','variable']].fillna(0)
         allout_list.append(dr_shed_dat)
 
     if write:
@@ -885,12 +888,12 @@ def main(
     alloutm = (
         pd.concat(allout_list)
         .pivot(
-            index=["r", "tech", "variable"], columns=["var"], values=["value"]
+            index=["r", "tech", "c", "variable"], columns=["var"], values=["value"]
         )
         .dropna()["value"]
         .reset_index()
-        .melt(id_vars=["r", "tech", "variable"])[
-            ["tech", "r", "var", "variable", "value"]
+        .melt(id_vars=["r", "tech", "c", "variable"])[
+            ["tech", "c", "r", "var", "variable", "value"]
         ]
         ### Rename the first column so GAMS reads the header as a comment
         .rename(columns={"tech": "*i", "var": "sc_cat", "variable": "rscbin"})
@@ -915,6 +918,7 @@ def main(
             geohydro_rsc.loc[geohydro_rsc.sc_cat == "cost", "value"] *= deflate[
                 "geo_rsc_{}".format(geohydrosupplycurve)
             ]
+            geohydro_rsc["c"] = geohydro_rsc["*i"].str.rsplit("_", n=1).str[1]
             geohydro_rsc["rscbin"] = "bin1"
             alloutm = pd.concat([alloutm, geohydro_rsc])
 
@@ -928,6 +932,7 @@ def main(
             egs_rsc.loc[egs_rsc.sc_cat == "cost", "value"] *= deflate[
                 "geo_rsc_{}".format(egssupplycurve)
             ]
+            egs_rsc["c"] = egs_rsc["*i"].str.rsplit("_", n=1).str[1]
             egs_rsc["rscbin"] = "bin1"
             alloutm = pd.concat([alloutm, egs_rsc])
 
@@ -942,12 +947,12 @@ def main(
         egsnearfield_rsc.loc[egsnearfield_rsc.sc_cat == "cost", "value"] *= deflate[
             "geo_rsc_{}".format(egsnearfieldsupplycurve)
         ]
+        egsnearfield_rsc["c"] = egsnearfield_rsc["*i"].str.rsplit("_", n=1).str[1]
         egsnearfield_rsc["rscbin"] = "bin1"
         alloutm = pd.concat([alloutm, egsnearfield_rsc])
 
     ### Combine with cost components
     alloutm = pd.concat([alloutm, cost_components_upv, cost_components_wind])
-    alloutm["c"] = alloutm["*i"].map(i2c)
     alloutm = alloutm[["*i", "c", "r", "sc_cat", "rscbin", "value"]]
     if write:
         alloutm.to_csv(
@@ -989,6 +994,7 @@ def main(
     ### UPV
     sitemap_upv = (
         upvin.assign(i="upv_" + upvin["class"].astype(str))
+        .assign(c=upvin["class"].astype(str))
         .assign(rscbin="bin" + upvin["bin"].astype(str))
         .assign(x="i" + upvin["sc_point_gid"].astype(str))
     )
@@ -996,13 +1002,14 @@ def main(
         sitemap_upv
         ### Assign rb's based on the no-exclusions transmission table
         .assign(r=sitemap_upv.x.map(spursites.set_index("x").r))[
-            ["i", "r", "rscbin", "x"]
+            ["i", "c", "r", "rscbin", "x"]
         ].rename(columns={"i": "*i"})
     )
     ### wind-ons
     sitemap_windons = (
         windin["ons"]
         .assign(i="wind-ons_" + windin["ons"]["class"].astype(str))
+        .assign(c=windin["ons"]["class"].astype(str))
         .assign(rscbin="bin" + windin["ons"]["bin"].astype(str))
         .assign(x="i" + windin["ons"]["sc_point_gid"].astype(str))
     )
@@ -1010,7 +1017,7 @@ def main(
         sitemap_windons
         ### Assign r's based on the no-exclusions transmission table
         .assign(r=sitemap_windons.x.map(spursites.set_index("x").r))[
-            ["i", "r", "rscbin", "x"]
+            ["i", "c", "r", "rscbin", "x"]
         ].rename(columns={"i": "*i"})
     )
 
@@ -1021,6 +1028,7 @@ def main(
         sitemap_geohydro = (
             geoin["geohydro"]
             .assign(i="geohydro_allkm_" + geoin["geohydro"]["class"].astype(str))
+            .assign(c=geoin["geohydro"]["class"].astype(str))
             .assign(rscbin="bin" + geoin["geohydro"]["bin"].astype(str))
             .assign(x="i" + geoin["geohydro"]["sc_point_gid"].astype(str))
         )
@@ -1028,7 +1036,7 @@ def main(
             sitemap_geohydro
             ### Assign rb's based on the no-exclusions transmission table
             .assign(r=sitemap_geohydro.x.map(spursites.set_index("x").r))[
-                ["i", "r", "rscbin", "x"]
+                ["i", "c", "r", "rscbin", "x"]
             ].rename(columns={"i": "*i"})
         )
         spurline_sitemap_list.append(sitemap_geohydro)
@@ -1037,6 +1045,7 @@ def main(
         sitemap_egs = (
             geoin["egs"]
             .assign(i="egs_allkm_" + geoin["egs"]["class"].astype(str))
+            .assign(c=geoin["egs"]["class"].astype(str))
             .assign(rscbin="bin" + geoin["egs"]["bin"].astype(str))
             .assign(x="i" + geoin["egs"]["sc_point_gid"].astype(str))
         )
@@ -1044,7 +1053,7 @@ def main(
             sitemap_egs
             ### Assign rb's based on the no-exclusions transmission table
             .assign(r=sitemap_egs.x.map(spursites.set_index("x").r))[
-                ["i", "r", "rscbin", "x"]
+                ["i", "c", "r", "rscbin", "x"]
             ].rename(columns={"i": "*i"})
         )
         spurline_sitemap_list.append(sitemap_egs)
@@ -1053,7 +1062,6 @@ def main(
     spurline_sitemap = spurline_sitemap.loc[
         spurline_sitemap.x.isin(spursites.x.values)
     ].copy()
-    spurline_sitemap["c"] = spurline_sitemap["*i"].map(i2c)
     spurline_sitemap = spurline_sitemap[["*i", "c", "r", "rscbin", "x"]]
     if write:
         spurline_sitemap.to_csv(

--- a/reeds/input_processing/writesupplycurves.py
+++ b/reeds/input_processing/writesupplycurves.py
@@ -52,18 +52,17 @@ def wm(df):
     return _wm
 
 
-def get_exog_cap(inputs_case, tech, dfsc, i2c):
+def get_exog_cap(inputs_case, tech, dfsc):
     """Get exogenous capacity by class, region, rscbin, and year"""
     dfexog = (
         pd.read_csv(os.path.join(inputs_case, f'exog_cap_{tech}.csv'))
         .merge(
-            dfsc.explode('sc_point_gid').reset_index()[['sc_point_gid','bin']],
+            dfsc.explode('sc_point_gid').reset_index()[['sc_point_gid','bin','class']],
             on='sc_point_gid',
         )
-        .rename(columns={'capacity':'MW'})
+        .rename(columns={'capacity':'MW', 'class':'c'})
     )
     dfexog['rscbin'] = dfexog['bin'].map('bin{}'.format)
-    dfexog['c'] = dfexog['*tech'].map(i2c)
     dfexog = dfexog.groupby(['*tech', 'c', 'region', 'rscbin', 'year']).MW.sum()
     return dfexog
 
@@ -250,6 +249,7 @@ def main(
             wind[s]
             .reset_index()
             .assign(i=f"wind-{s}_" + wind[s].reset_index()["class"].astype(str))
+            .assign(c=wind[s].reset_index()["class"].astype(str))
             .assign(rscbin="bin" + wind[s].reset_index()["bin"].astype(str))
             .rename(columns={"region": "r"})
         )
@@ -298,9 +298,9 @@ def main(
 
     if write:
         ## Exogenous wind capacity
-        exog_wind_ons_rsc = get_exog_cap(inputs_case, tech='wind-ons', dfsc=wind['ons'], i2c=i2c)
+        exog_wind_ons_rsc = get_exog_cap(inputs_case, tech='wind-ons', dfsc=wind['ons'])
         exog_wind_ons_rsc.round(3).to_csv(os.path.join(inputs_case, "exog_wind_ons_rsc.csv"))
-        exog_wind_ofs_rsc = get_exog_cap(inputs_case, tech='wind-ofs', dfsc=wind['ofs'], i2c=i2c)
+        exog_wind_ofs_rsc = get_exog_cap(inputs_case, tech='wind-ofs', dfsc=wind['ofs'])
         exog_wind_ofs_rsc.round(3).to_csv(os.path.join(inputs_case, "exog_wind_ofs_rsc.csv"))
 
     # %%###############
@@ -340,7 +340,7 @@ def main(
 
     if write:    
         ## Exogenous UPV capacity
-        exog_upv_rsc = get_exog_cap(inputs_case, tech='upv', dfsc=upv, i2c=i2c)
+        exog_upv_rsc = get_exog_cap(inputs_case, tech='upv', dfsc=upv)
         exog_upv_rsc.round(3).to_csv(os.path.join(inputs_case, "exog_upv_rsc.csv"))
 
     ### Normalize formatting
@@ -350,6 +350,7 @@ def main(
 
     spurout_list.append(
         upv.assign(i="upv_" + upv["class"].astype(str).str.strip("class"))
+        .assign(c=upv["class"].astype(str).str.strip("class"))
         .assign(rscbin="bin" + upv["bin"].str.strip("upvsc"))
         .rename(columns={"region": "r"})
     )
@@ -402,6 +403,7 @@ def main(
 
         spurout_list.append(
             csp.assign(i="csp_" + csp["class"].astype(str).str.strip("class"))
+            .assign(c=csp["class"].astype(str).str.strip("class"))
             .assign(rscbin="bin" + csp["bin"].str.strip("cspsc"))
             .rename(columns={"region": "r"})
         )
@@ -479,6 +481,7 @@ def main(
                 geo[s]
                 .reset_index()
                 .assign(i=f"{s}_allkm_" + geo[s].reset_index()["class"].astype(str))
+                .assign(c=geo[s].reset_index()["class"].astype(str))
                 .assign(rscbin="bin" + geo[s].reset_index()["bin"].astype(str))
                 .rename(columns={"region": "r"})
             )
@@ -558,7 +561,7 @@ def main(
 
             if use_geohydro_rev_sc:
                 ## Exogenous geohydro capacity
-                exog_geohydro_rsc = get_exog_cap(inputs_case, tech='geohydro', dfsc=geo['geohydro'], i2c=i2c)
+                exog_geohydro_rsc = get_exog_cap(inputs_case, tech='geohydro', dfsc=geo['geohydro'])
                 exog_geohydro_rsc.round(3).to_csv(
                     os.path.join(inputs_case, "exog_geohydro_allkm_rsc.csv")
                 )
@@ -566,6 +569,7 @@ def main(
     # %% Get supply-curve data for postprocessing
     spurcols = [
         'i',
+        'c',
         'r',
         'rscbin',
         'capacity',
@@ -602,7 +606,6 @@ def main(
         ## Reformat to save for GAMS
         .rename(columns={"i": "*i"})
     )
-    poi_distance_out["c"] = poi_distance_out["*i"].map(i2c)
     poi_distance_out = poi_distance_out.set_index(["*i", "c", "r", "rscbin"])
     ## Convert to miles
     distance_spur = (poi_distance_out.dist_spur_km.rename("miles") / 1.609).round(3)

--- a/reeds/input_processing/writesupplycurves.py
+++ b/reeds/input_processing/writesupplycurves.py
@@ -220,7 +220,7 @@ def main(
             .rename(
                 columns={
                     "region": "r",
-                    "class": "*i",
+                    "class": "c",
                     "bin": "rscbin",
                     "cost_total_trans_usd_per_mw": "cost_trans",
                     "capital_adder_per_mw": "cost_cap",
@@ -228,10 +228,8 @@ def main(
             )
         )
 
-        cost_components["c"] = cost_components["*i"].astype(str)
-        cost_components["*i"] = f"wind-{s}_" + cost_components[
-            "*i"
-        ].astype(str)
+        cost_components["c"] = cost_components["c"].astype(str)
+        cost_components["*i"] = f"wind-{s}_" + cost_components["c"]
         cost_components["rscbin"] = "bin" + cost_components[
             "rscbin"
         ].astype(str)
@@ -321,14 +319,14 @@ def main(
     cost_components_upv = cost_components_upv.rename(
         columns={
             "region": "r",
-            "class": "*i",
+            "class": "c",
             "bin": "rscbin",
             "cost_total_trans_usd_per_mw": "cost_trans",
             "capital_adder_per_mw": "cost_cap",
         }
     )
-    cost_components_upv["c"] = cost_components_upv["*i"].astype(str)
-    cost_components_upv["*i"] = "upv_" + cost_components_upv["*i"].astype(str)
+    cost_components_upv["c"] = cost_components_upv["c"].astype(str)
+    cost_components_upv["*i"] = "upv_" + cost_components_upv["c"]
     cost_components_upv["rscbin"] = "bin" + cost_components_upv["rscbin"].astype(str)
     cost_components_upv = pd.melt(
         cost_components_upv,

--- a/reeds/io.py
+++ b/reeds/io.py
@@ -1445,7 +1445,7 @@ def get_available_capacity_weighted_cf(case, level='country'):
         .reset_index(level='drop', drop=True).reset_index()
     )
     sc['i'] = sc.tech+'_'+sc['class'].astype(str)
-    sc['resource'] = sc.i + '|' + sc.region
+    sc['resource'] = sc.i + '|' + sc['class'].astype(str) + '|' + sc.region
     sc['aggreg'] = sc.region.map(r2region)
     ## Get CF
     recf = reeds.io.read_file(
@@ -1455,7 +1455,7 @@ def get_available_capacity_weighted_cf(case, level='country'):
     recapcf = (recf * sc.set_index('resource')['capacity']).dropna(axis=1, how='all')
     recapcf.columns = pd.MultiIndex.from_arrays([
         recapcf.columns.map(lambda x: x.split('|')[0].strip('_0123456789')),
-        recapcf.columns.map(lambda x: r2region[x.split('|')[1]]),
+        recapcf.columns.map(lambda x: r2region[x.split('|')[-1]]),
     ], names=['i', 'r'])
     dfout = (
         recapcf.T.groupby(['i','r']).sum().T

--- a/reeds/reedsplots.py
+++ b/reeds/reedsplots.py
@@ -6192,7 +6192,7 @@ def get_cf_map(case, tech='wind-ons', timestamp=None, recf=None, crs='EPSG:5070'
         )
     if not isinstance(recf.columns, pd.core.indexes.multi.MultiIndex):
         recf.columns = pd.MultiIndex.from_tuples(
-            recf.columns.map(lambda x: tuple(x.split('|'))),
+            recf.columns.map(lambda x: (x.split('|')[0], x.split('|')[-1])),
             names=['i','r'],
         )
     ## Downselect to time range and technology of interest
@@ -6334,7 +6334,7 @@ def map_stressors(
 
     vre_gen = reeds.io.read_file(ra_files['vre_gen'])
     vre_gen.columns = pd.MultiIndex.from_tuples(
-        vre_gen.columns.map(lambda x: tuple(x.split('|'))),
+        vre_gen.columns.map(lambda x: (x.split('|')[0], x.split('|')[-1])),
         names=['i','r'],
     )
 
@@ -6342,7 +6342,7 @@ def map_stressors(
         os.path.join(case, 'inputs_case', 'recf.h5'),
     )
     recf.columns = pd.MultiIndex.from_tuples(
-        recf.columns.map(lambda x: tuple(x.split('|'))),
+        recf.columns.map(lambda x: (x.split('|')[0], x.split('|')[-1])),
         names=['i','r'],
     )
 

--- a/reeds/resource_adequacy/capacity_credit.py
+++ b/reeds/resource_adequacy/capacity_credit.py
@@ -118,7 +118,8 @@ def reeds_cc(t, tnext, casedir):
     #%% Load some inputs
     inputs_case = os.path.join(casedir, 'inputs_case')
     hierarchy = reeds.io.get_hierarchy(casedir).reset_index()
-    resources = pd.read_csv(os.path.join(inputs_case, 'resources.csv'))
+    resources = pd.read_csv(
+        os.path.join(inputs_case, 'resources.csv'), dtype={'c': str})
     
     reeds_data = os.path.join(casedir, 'handoff', 'reeds_data')
     cap = pd.read_csv(os.path.join(reeds_data, f'max_cap_{t}.csv'))

--- a/reeds/resource_adequacy/diagnostic_plots.py
+++ b/reeds/resource_adequacy/diagnostic_plots.py
@@ -111,7 +111,7 @@ def get_inputs(sw):
     ### Get vre_gen summed over tech by BA (full 7 years)
     vre_gen_r = (
         vre_gen
-        .rename(columns=dict(zip(vre_gen.columns, vre_gen.columns.map(lambda x: x.split('|')[1]))))
+        .rename(columns=dict(zip(vre_gen.columns, vre_gen.columns.map(lambda x: x.split('|')[-1]))))
         .T.groupby(level=0).sum().T
     )
 
@@ -811,7 +811,7 @@ def plot_pras_load_units(sw, dfs):
     ## Net demand
     vre_gen = dfs['vre_gen'].copy()
     vre_gen.columns = pd.MultiIndex.from_tuples(
-        vre_gen.columns.map(lambda x: tuple(x.split('|'))),
+        vre_gen.columns.map(lambda x: (x.split('|')[0], x.split('|')[-1])),
         names=['i','r'],
     )
     net_demand = (dfs['pras_system']['load'] - vre_gen.T.groupby('r').sum().T) / 1e3

--- a/reeds/resource_adequacy/diagnostic_plots.py
+++ b/reeds/resource_adequacy/diagnostic_plots.py
@@ -76,7 +76,7 @@ def get_inputs(sw):
     hierarchy = reeds.io.get_hierarchy(sw.casedir)
 
     resources = pd.read_csv(
-        os.path.join(sw['casedir'],'inputs_case','resources.csv')
+        os.path.join(sw['casedir'],'inputs_case','resources.csv'), dtype={'c': str}
     ).set_index('resource')
     resources['tech'] = reeds.reedsplots.simplify_techs(resources.i, display_level = 'diagnostics')
     resources['rb'] = resources.r

--- a/reeds/resource_adequacy/prep_data.py
+++ b/reeds/resource_adequacy/prep_data.py
@@ -152,7 +152,7 @@ def main(t, casedir, iteration=0):
     resources = pd.read_csv(os.path.join(inputs_case, 'resources.csv'))
     recf = reeds.io.read_file(os.path.join(inputs_case, 'recf.h5'))
     recf.columns = pd.MultiIndex.from_tuples([tuple(x.split('|')) for x in recf.columns],
-                                             names=('i','r'))
+                                             names=('i','c','r'))
 
     tech_subset_table = reeds.techs.expand_GAMS_tech_groups(
         reeds.techs.get_tech_subset_table(casedir).reset_index()
@@ -255,7 +255,7 @@ def main(t, casedir, iteration=0):
             "CF adjustment didn't work; probably missing values in cf_adj_t_filt. "
             f"len(cap_vre) = {len(cap_vre)}; len(cap_vre_derated) = {(len(cap_vre_derated))}."
         )
-    cap_vre_derated = cap_vre_derated.groupby(['i','r']).Value.sum()
+    cap_vre_derated = cap_vre_derated.groupby(['i','c','r']).Value.sum()
 
     ### Multiply derated capacity by CF to get generation
     gen_vre_ir = recf.multiply(cap_vre_derated, axis=1).dropna(axis=1)
@@ -273,7 +273,7 @@ def main(t, casedir, iteration=0):
     gen_vre_r = gen_vre_r.T.groupby(level='r').sum().T
 
     ### Store generation by (i,r) for capacity_credit.py
-    gen_vre_resources = gen_vre_ir.reindex(resources[['i','r']], axis=1).fillna(0).clip(lower=0)
+    gen_vre_resources = gen_vre_ir.reindex(resources[['i','c','r']], axis=1).fillna(0).clip(lower=0)
 
     vre_gen_exist = gen_vre_resources.copy()
     vre_gen_exist.columns = ['|'.join(c) for c in vre_gen_exist.columns]
@@ -315,7 +315,7 @@ def main(t, casedir, iteration=0):
     ### Multiply [CF] * [CF adjustment] to get marginal CF
     vre_cf_marg = (
         recf.multiply(cf_adj_i, level='i', axis=1)
-        .reindex(resources[['i','r']], axis=1)
+        .reindex(resources[['i','c','r']], axis=1)
     )
     vre_cf_marg.columns = ['|'.join(c) for c in vre_cf_marg.columns]
     vre_cf_marg.index = h_dt_szn.set_index(['ccseason','year','h','hour']).index

--- a/reeds/resource_adequacy/prep_data.py
+++ b/reeds/resource_adequacy/prep_data.py
@@ -149,7 +149,8 @@ def main(t, casedir, iteration=0):
 
     load = reeds.io.read_file(os.path.join(inputs_case, 'load.h5'))
 
-    resources = pd.read_csv(os.path.join(inputs_case, 'resources.csv'))
+    resources = pd.read_csv(
+        os.path.join(inputs_case, 'resources.csv'), dtype={'c': str})
     recf = reeds.io.read_file(os.path.join(inputs_case, 'recf.h5'))
     recf.columns = pd.MultiIndex.from_tuples([tuple(x.split('|')) for x in recf.columns],
                                              names=('i','c','r'))

--- a/reeds/results.py
+++ b/reeds/results.py
@@ -529,7 +529,8 @@ def calc_reinforcement_spur_capacity_miles(case):
     val_r = reeds.io.read_input(case, 'r').squeeze(1).values
 
     # Get the spur/reinforcement distance for each i/r/rscbin  
-    spur_parameters = pd.read_csv(os.path.join(inputs_case, 'spur_parameters.csv'))
+    spur_parameters = pd.read_csv(
+        os.path.join(inputs_case, 'spur_parameters.csv'), dtype={'c': str})
 
     # Get added capacity by i/v/r/t/rscbin
     cap_new_bin_out = reeds.io.read_output(case, 'cap_new_bin_out')
@@ -540,8 +541,9 @@ def calc_reinforcement_spur_capacity_miles(case):
         inplace=True)
 
     # Sum new capacity by technology and resource bin
+    cap_new_bin_out['c'] = cap_new_bin_out['c'].astype(str)
     cap_new_bin_out = cap_new_bin_out.groupby(
-        ['i', 'r', 'rscbin', 'year'], as_index=False)['New Cap (GW)'].sum()
+        ['i', 'c', 'r', 'rscbin', 'year'], as_index=False)['New Cap (GW)'].sum()
 
     # Convert UPV from DC to AC
     upv_mask = cap_new_bin_out['i'].str.startswith('upv')
@@ -551,7 +553,8 @@ def calc_reinforcement_spur_capacity_miles(case):
     cap_new_filtered = cap_new_bin_out[cap_new_bin_out['i'].str.startswith(('wind', 'upv', 'csp'))]
 
     # Merge spur parameters
-    cap_new_filtered = cap_new_filtered.merge(spur_parameters, on=['i', 'r', 'rscbin'], how='left')
+    cap_new_filtered = cap_new_filtered.merge(
+        spur_parameters, on=['i', 'c', 'r', 'rscbin'], how='left')
 
     # Compute spur and reinforcement distances (GW-mi)
     tech_trans = pd.concat([


### PR DESCRIPTION
## Summary
(Note: this is getting merged into a dev branch and not into main)

This PR continues #185 to separate the resource class from the technology.  I thought I was ready to start collapsing the technology sets, but found several other places where class expansion was needed, or where it would eventually would be required.  This pull request continues the class expansion, but still ignores some capacity credit parameters (I want to do those in a separate PR because they will use the capacity credit switch which is off by default).

This PR is 6a in the list at https://github.com/ReEDS-Model/ReEDS/issues/185#issuecomment-5427027139.

## Technical details <!-- if any, otherwise delete -->

### Implementation notes <!-- if any, otherwise delete -->
The primary changes were with exogenous capacity and prescribed builds, which now carry class.  The resources class addition was further propagated.  And the additional mapping of class meant that the `i2c` mapping in `writesupplycurves.py` could be removed.

### Issues resolved <!-- if any, otherwise delete -->
Partially addresses #185.

### Known incompatibilities <!-- if any, otherwise delete -->
R2X has not yet been fixed.

### Relevant sources or documentation <!-- if any, otherwise delete -->

## Validation, testing, and comparison report(s)
The Pacific test case showed that all outputs were exactly the same.  The USA_defaults test case was exactly identical until 2035, where the objective function differred by 1e-14.  That tiny difference propagated into the other tiny differences in 2040 and beyond.  The objective function stayed within 1e-4, and the model size was exactly the same in every solve year and iteration after the change.

USA_defaults capacity difference:

<img width="2000" height="561" alt="image" src="https://github.com/user-attachments/assets/93f94bb5-728e-4da5-8cce-6eeb9d0f9eba" />

USA_defaults compare report: [results-Baseline,ClassExpand.pptx](https://github.com/user-attachments/files/32117620/results-Baseline.ClassExpand.pptx)

## Checklist for author
<!-- Fill out before requesting review -->

### Details to double-check
<!-- Delete or ~~strikethrough~~ if not relevant for this PR -->
- [x] Charge code provided to reviewers
- [x] Included comparison reports for appropriate test cases
- ~~[ ] Documentation updated if necessary~~
  <!--
  - model_documentation.md: High-level description of default model behavior
  - user_guide.md: User/developer-facing description of model switches and input files
  - faq.md: Limitations, caveats, and known issues
  - postprocessing_tools.md: User/developer-facing description of scripts in postprocessing folder
  - README.md files: User/developer facing description of individual input folders
  -->
- [x] Code formatting standardized <!-- Coding conventions: https://reeds-model.github.io/ReEDS/developer_best_practices.html#coding-standards-and-conventions -->
- [x] Reusable functions used where possible instead of copy/pasted code

### General information to guide review
<!-- These do not need to be checked to merge, but if unchecked, a deeper level of review may be required -->
- [ ] Zero impact on results of default case
- [x] No large data file(s) added/modified
- [x] No substantive impact on runtime for full-US reference case
- [x] No substantive impact on folder size for full-US reference case
- [x] No change to process flow (runreeds.py, reeds/core/solve/solve.py)
- [x] No change to code organization
- [x] No change to package requirements (environment.yml or Project.toml)

#### Did you use LLM tools (chatbot or copilot) in the preparation of this PR? If so, describe how
Yes, I used Claude Opus 5 to implement the code changes and to help me with verification of those changes (e.g., reading .lst files for model size, comparing outputs, etc.).

### Tag points of contact here if you would like additional review of the relevant parts of the model
<!-- Model dimensions -->
<!-- - [ ] County resolution: @louisaserpe -->
<!-- - [ ] Demand data: @ahamilton5 -->
<!-- - [ ] Emissions: @atpham88 -->
<!-- - [ ] Financial calculations: @wesleyjcole -->
<!-- - [ ] FINITO: @merveturan or @cavraam -->
<!-- - [ ] Hybrids: @aschleif -->
<!-- - [ ] Monte Carlo: @bsergi -->
<!-- - [ ] Sparse chronology or interday diurnal storage: @Yunzhi-Chen -->
<!-- - [ ] State policies: @wesleyjcole or @aschleif -->
<!-- - [ ] Stress periods, resource adequacy, or ReEDS2PRAS/Julia: @patrickbrown4 -->
<!-- - [ ] Supply curves, hourlize, reeds_to_rev: @bsergi -->
<!-- - [ ] Time resolution: @patrickbrown4 -->
<!-- - [ ] Water cooling: @jcarag or @stuartcohen8 -->

<!-- Pre/Postprocessing -->
<!-- - [ ] Dispatch mode (run_pcm.py): @patrickbrown4 -->
<!-- - [ ] Github actions: @kennedy-mindermann -->
<!-- - [ ] Health impacts: @bsergi -->
<!-- - [ ] Input data structure and processing: @kodiobika -->
<!-- - [ ] Interactive plots (bokeh, vizit): @mmowers -->
<!-- - [ ] Land use: @bsergi -->
<!-- - [ ] R2X: @pesap -->
<!-- - [ ] Retail rates: @wesleyjcole -->
<!-- - [ ] Static plots (single_case_plots.py, compare_cases.py): @patrickbrown4 -->
<!-- - [ ] Tableau: @ahamilton5 -->
<!-- - [ ] Technology value (reValue, valuestreams.py): @mmowers -->

<!-- Technologies -->
<!-- - [ ] Batteries: @wesleyjcole -->
<!-- - [ ] EV managed charging (EVMC): @Max-Vanatta -->
<!-- - [ ] Fossil, CCS, or DAC: @mbrown1 -->
<!-- - [ ] Geothermal: @shashwatsharma24 -->
<!-- - [ ] Hydropower or PSH: @stuartcohen8 -->
<!-- - [ ] Hydrogen: @bsergi -->
<!-- - [ ] Nuclear: @wesleyjcole -->
<!-- - [ ] Solar: @wesleyjcole -->
<!-- - [ ] Transmission: @patrickbrown4 -->
<!-- - [ ] Wind: @mmowers -->
